### PR TITLE
Filter by main setting

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "react-bootstrap": "^2.4.0",
         "react-dom": "^18.2.0",
         "react-infinite-scroll-component": "^6.1.0",
+        "react-infinite-scroller": "^1.2.6",
         "react-router-dom": "^6.3.0",
         "react-scripts": "5.0.1",
         "react-spinners": "^0.13.4",
@@ -14545,6 +14546,17 @@
         "react": ">=16.0.0"
       }
     },
+    "node_modules/react-infinite-scroller": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/react-infinite-scroller/-/react-infinite-scroller-1.2.6.tgz",
+      "integrity": "sha512-mGdMyOD00YArJ1S1F3TVU9y4fGSfVVl6p5gh/Vt4u99CJOptfVu/q5V/Wlle72TMgYlBwIhbxK5wF0C/R33PXQ==",
+      "dependencies": {
+        "prop-types": "^15.5.8"
+      },
+      "peerDependencies": {
+        "react": "^0.14.9 || ^15.3.0 || ^16.0.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
     "node_modules/react-is": {
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
@@ -27610,6 +27622,14 @@
       "integrity": "sha512-SQu5nCqy8DxQWpnUVLx7V7b7LcA37aM7tvoWjTLZp1dk6EJibM5/4EJKzOnl07/BsM1Y40sKLuqjCwwH/xV0TQ==",
       "requires": {
         "throttle-debounce": "^2.1.0"
+      }
+    },
+    "react-infinite-scroller": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/react-infinite-scroller/-/react-infinite-scroller-1.2.6.tgz",
+      "integrity": "sha512-mGdMyOD00YArJ1S1F3TVU9y4fGSfVVl6p5gh/Vt4u99CJOptfVu/q5V/Wlle72TMgYlBwIhbxK5wF0C/R33PXQ==",
+      "requires": {
+        "prop-types": "^15.5.8"
       }
     },
     "react-is": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
         "react-infinite-scroll-component": "^6.1.0",
         "react-router-dom": "^6.3.0",
         "react-scripts": "5.0.1",
+        "react-spinners": "^0.13.4",
         "react-transition-group": "^4.4.5",
         "web-vitals": "^2.1.4"
       }
@@ -14658,6 +14659,15 @@
         }
       }
     },
+    "node_modules/react-spinners": {
+      "version": "0.13.4",
+      "resolved": "https://registry.npmjs.org/react-spinners/-/react-spinners-0.13.4.tgz",
+      "integrity": "sha512-V6IURjYOwomhdngMfuVxBp4utCF6v21sjQ6r4K2JoKl8fwXZp1UeHMBLf+2SU+cts8hAVj9rHOJ8kdT5UqqaJw==",
+      "peerDependencies": {
+        "react": "^16.0.0 || ^17.0.0 || ^18.0.0",
+        "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
     "node_modules/react-transition-group": {
       "version": "4.4.5",
       "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-4.4.5.tgz",
@@ -27688,6 +27698,12 @@
         "webpack-manifest-plugin": "^4.0.2",
         "workbox-webpack-plugin": "^6.4.1"
       }
+    },
+    "react-spinners": {
+      "version": "0.13.4",
+      "resolved": "https://registry.npmjs.org/react-spinners/-/react-spinners-0.13.4.tgz",
+      "integrity": "sha512-V6IURjYOwomhdngMfuVxBp4utCF6v21sjQ6r4K2JoKl8fwXZp1UeHMBLf+2SU+cts8hAVj9rHOJ8kdT5UqqaJw==",
+      "requires": {}
     },
     "react-transition-group": {
       "version": "4.4.5",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "react-infinite-scroll-component": "^6.1.0",
     "react-router-dom": "^6.3.0",
     "react-scripts": "5.0.1",
+    "react-spinners": "^0.13.4",
     "react-transition-group": "^4.4.5",
     "web-vitals": "^2.1.4"
   },

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "react-bootstrap": "^2.4.0",
     "react-dom": "^18.2.0",
     "react-infinite-scroll-component": "^6.1.0",
+    "react-infinite-scroller": "^1.2.6",
     "react-router-dom": "^6.3.0",
     "react-scripts": "5.0.1",
     "react-spinners": "^0.13.4",

--- a/src/App.js
+++ b/src/App.js
@@ -1,5 +1,5 @@
 import { BrowserRouter, Routes, Route } from "react-router-dom"
-import { useState } from "react"
+import { useState, useEffect } from "react"
 
 import HomePage from "./components/HomePage/HomePage"
 import PageNotFound from "./components/PageNotFound/PageNotFound"
@@ -12,11 +12,18 @@ import "./App.css"
 const App = () => {
   const [resultsList, setResultsList] = useState([]) // array of Objects
   const [tuneBook, setTuneBook] = useState([]) // array of Objects
+  const [practiceDiary, setPracticeDiary] = useState([]) // array of Objects
+  const [preferredSettings, setPreferredSettings] = useState({}) // {tuneID: setting} pairs (setting is zero-indexed)
   const [filters, setFilters] = useState({
     type: "",
     mode: { key: "", modeType: "" },
     q: "",
     inTuneBook: false,
+    showTransposedTunes: false,
+  })
+  const [userPrefs, setUserPrefs] = useState({
+    thesessionMemberId: 151540,
+    showOnlyPrimarySettings: true, // only return a tune result if its FIRST setting matches the filters (otherwise return the tune result if ANY setting matches filters)
   })
 
   const isInTuneBook = (lookFor) => {
@@ -43,6 +50,36 @@ const App = () => {
     }
   }
 
+  const managePreferredSettings = (action, tuneId, settingId = -1) => {
+    if (action === "set" && settingId >= 0) {
+      const newSettings = { ...preferredSettings, [tuneId]: settingId }
+      setPreferredSettings(newSettings)
+    }
+    if (action === "remove") {
+      const newSettings = { ...preferredSettings }
+      delete newSettings[tuneId]
+      setPreferredSettings(newSettings)
+    }
+  }
+
+  useEffect(() => {
+    console.log('Loading preferredSettings from localStorage')
+    const savedPreferredSettings = JSON.parse(
+      localStorage.getItem("preferredSettings")
+    )
+    if (savedPreferredSettings) {
+      console.log('Loaded preferredSettings:', savedPreferredSettings)
+      setPreferredSettings(savedPreferredSettings)
+    } else {
+      console.log('No saved preferredSettings found')
+    }
+  }, [])
+
+  useEffect(() => {
+    console.log('Saving preferredSettings as:', preferredSettings)
+    localStorage.setItem("preferredSettings", JSON.stringify(preferredSettings))
+  }, [preferredSettings])
+
   return (
     <div className="App" data-testid="App">
       <BrowserRouter>
@@ -61,6 +98,12 @@ const App = () => {
                 setResultsList={setResultsList}
                 filters={filters}
                 setFilters={setFilters}
+                userPrefs={userPrefs}
+                setUserPrefs={setUserPrefs}
+                practiceDiary={practiceDiary}
+                setPracticeDiary={setPracticeDiary}
+                preferredSettings={preferredSettings}
+                managePreferredSettings={managePreferredSettings}
               />
             }
           />
@@ -71,6 +114,16 @@ const App = () => {
               <TuneNotation
                 tuneBook={tuneBook}
                 toggleTuneBookEntry={toggleTuneBookEntry}
+                resultsList={resultsList}
+                setResultsList={setResultsList}
+                filters={filters}
+                setFilters={setFilters}
+                userPrefs={userPrefs}
+                setUserPrefs={setUserPrefs}
+                practiceDiary={practiceDiary}
+                setPracticeDiary={setPracticeDiary}
+                preferredSettings={preferredSettings}
+                managePreferredSettings={managePreferredSettings}
               />
             }
           >
@@ -80,6 +133,16 @@ const App = () => {
                 <TuneNotation
                   tuneBook={tuneBook}
                   toggleTuneBookEntry={toggleTuneBookEntry}
+                  resultsList={resultsList}
+                  setResultsList={setResultsList}
+                  filters={filters}
+                  setFilters={setFilters}
+                  userPrefs={userPrefs}
+                  setUserPrefs={setUserPrefs}
+                  practiceDiary={practiceDiary}
+                  setPracticeDiary={setPracticeDiary}
+                  preferredSettings={preferredSettings}
+                  managePreferredSettings={managePreferredSettings}
                 />
               }
             />
@@ -91,6 +154,16 @@ const App = () => {
               <TuneBook
                 tuneBook={tuneBook}
                 toggleTuneBookEntry={toggleTuneBookEntry}
+                resultsList={resultsList}
+                setResultsList={setResultsList}
+                filters={filters}
+                setFilters={setFilters}
+                userPrefs={userPrefs}
+                setUserPrefs={setUserPrefs}
+                practiceDiary={practiceDiary}
+                setPracticeDiary={setPracticeDiary}
+                preferredSettings={preferredSettings}
+                managePreferredSettings={managePreferredSettings}
               />
             }
           >
@@ -100,6 +173,16 @@ const App = () => {
                 <TuneNotation
                   tuneBook={tuneBook}
                   toggleTuneBookEntry={toggleTuneBookEntry}
+                  resultsList={resultsList}
+                  setResultsList={setResultsList}
+                  filters={filters}
+                  setFilters={setFilters}
+                  userPrefs={userPrefs}
+                  setUserPrefs={setUserPrefs}
+                  practiceDiary={practiceDiary}
+                  setPracticeDiary={setPracticeDiary}
+                  preferredSettings={preferredSettings}
+                  managePreferredSettings={managePreferredSettings}
                 />
               }
             />
@@ -111,6 +194,16 @@ const App = () => {
               <Practice
                 tuneBook={tuneBook}
                 toggleTuneBookEntry={toggleTuneBookEntry}
+                resultsList={resultsList}
+                setResultsList={setResultsList}
+                filters={filters}
+                setFilters={setFilters}
+                userPrefs={userPrefs}
+                setUserPrefs={setUserPrefs}
+                practiceDiary={practiceDiary}
+                setPracticeDiary={setPracticeDiary}
+                preferredSettings={preferredSettings}
+                managePreferredSettings={managePreferredSettings}
               />
             }
           />

--- a/src/components/FilterSelect/FilterSelect.js
+++ b/src/components/FilterSelect/FilterSelect.js
@@ -10,14 +10,16 @@ export default function FilterSelect({
   setFilters,
   setResultsList,
   setPage,
+  controller,
 }) {
   Pluralize.addPluralRule(/waltz/i, "waltzes") // 🙄
 
   const changeKey = (e) => {
     setFilters((prevFilters) => ({
       ...prevFilters,
-      mode: { key: e.target.value, modeType: prevFilters.mode.modeType },
+      mode: { ...prevFilters.mode, key: e.target.value },
     }))
+    console.log(`KEY FILTER changed to ${e.target.value}. new filters:`, filters)
     setResultsList([])
     setPage(1)
   }

--- a/src/components/HomePage/HomePage.js
+++ b/src/components/HomePage/HomePage.js
@@ -1,10 +1,10 @@
-import Pluralize from "pluralize"
 import { useState, useEffect, useCallback } from "react"
-import InfiniteScroll from "react-infinite-scroll-component"
+import ClearIcon from "@mui/icons-material/Clear"
+// import InfiniteScroll from "react-infinite-scroll-component"
 import ExpandMoreIcon from "@mui/icons-material/ExpandMore"
 import ExpandLessIcon from "@mui/icons-material/ExpandLess"
-import ClearIcon from "@mui/icons-material/Clear"
-import PulseLoader from "react-spinners/PulseLoader"
+import Pluralize from "pluralize"
+// import PulseLoader from "react-spinners/PulseLoader"
 
 import FilterSelect from "../FilterSelect/FilterSelect"
 import TuneResult from "../TuneResult/TuneResult"
@@ -13,104 +13,153 @@ import "./HomePage.css"
 export default function HomePage({
   tuneBook,
   toggleTuneBookEntry,
-  setResultsList,
   resultsList,
+  setResultsList,
   filters,
   setFilters,
+  userPrefs,
+  setUserPrefs,
 }) {
+  const [page, setPage] = useState(1)
   const [totalPages, setTotalPages] = useState(0)
   const [totalResults, setTotalResults] = useState(0)
-  const [page, setPage] = useState(1)
   // resultsStatus can be 'initialising', 'searching', 'checking results', 'results found' or 'no results'
   const [resultsStatus, setResultsStatus] = useState("initialising")
   const [showFilterOptions, setShowFilterOptions] = useState(false)
   Pluralize.addPluralRule(/waltz/i, "waltzes") // 🙄
 
+  const filterString = `type=${filters.type}&mode=${
+    filters.mode.key
+      ? filters.mode.key + (filters.mode.modeType || "major")
+      : ""
+  }&q=${filters.q}`
+
   const dealWithresults = useCallback(
     (data) => {
-      console.log("DEALING WITH VALID RESULTS")
+      console.log("dealWithResults() called")
       setResultsStatus("results found")
       setTotalPages(data.pages)
       setTotalResults(data.total)
-      if (page === 1) {
-        setResultsList(data.tunes)
-        console.log("Just loaded first page of results")
+
+      data.tunes.forEach((tune) => {
+        console.log("Getting data for tune #", tune.id)
+        const url = `https://thesession.org/tunes/${tune.id}?format=json`
+        fetch(url)
+          .then((response) => response.json())
+          .then((data) => {
+            console.log(`Data for tune #${tune.id}`, data)
+            // determine if 'showOnlyPrimarySettings' filter is applicable
+            if (
+              userPrefs.showOnlyPrimarySettings &&
+              (filters.mode.key || filters.mode.modeType)
+            ) {
+              // only add this result if the FIRST setting matches user filters
+              if (
+                `${data.settings[0].key}` ===
+                `${
+                  filters.mode.key +
+                  (filters.mode.modeType ? filters.mode.modeType : "major")
+                }`
+              ) {
+                console.log(
+                  `TUNE ${data.id}'s primary setting is in ${
+                    data.settings[0].key
+                  } --> adding to list! (match: ${
+                    filters.mode.key +
+                    (filters.mode.modeType ? filters.mode.modeType : "major")
+                  })`
+                )
+                setResultsList((oldList) => [...oldList, data])
+              } else {
+                console.log(
+                  `TUNE ${data.id}'s primary setting is in ${
+                    data.settings[0].key
+                  } --> REJECT (no match: ${
+                    filters.mode.key +
+                    (filters.mode.modeType ? filters.mode.modeType : "major")
+                  })`
+                )
+              }
+            } else {
+              // add all results to results list
+              console.log(
+                `showOnlyPrimarySettings=${userPrefs.showOnlyPrimarySettings}, filters.mode.key=${filters.mode.key}, filters.mode.modeType=${filters.mode.modeType}. adding tune ${tune.id} to results.`
+              )
+              setResultsList((oldList) => [...oldList, data])
+            }
+          })
+      })
+    },
+    [
+      setResultsList,
+      filters.mode.key,
+      filters.mode.modeType,
+      userPrefs.showOnlyPrimarySettings,
+    ]
+  )
+
+  const checkResults = useCallback(
+    (data) => {
+      console.log(`checkResults() called`)
+      /* The server doesn't return zero results for a key/mode query with no 
+       results, it returns the entire archive. This function deals with it. */
+      const THRESHOLD = 1000
+      if (filters.mode.key && data.total > THRESHOLD) {
+        console.log(`Received ${data.total} results - performing check`)
+        setResultsStatus("checking results")
+        const testString = `type=${filters.type}&q=${filters.q}`
+        const entireArchiveUrl = `https://thesession.org/tunes/search?${testString}&format=json`
+        console.log(`Test API call:`, entireArchiveUrl)
+        fetch(entireArchiveUrl)
+          .then((entireArchive) => entireArchive.json())
+          .then((entireArchiveData) => {
+            if (data.total >= entireArchiveData.total) {
+              console.log(
+                `data.total (${data.total}) >= entireArchiveData.total (${entireArchiveData.total}), so NO RESULTS`
+              )
+              setResultsStatus("no results")
+              setResultsList([])
+            } else {
+              console.log(
+                `data.total (${data.total}) < entireArchiveData.total (${entireArchiveData.total}), so RESULTS OK`
+              )
+              setResultsStatus("results found")
+              dealWithresults(data)
+            }
+          })
+      } else if (data.total === 0) {
+        console.log("Not performing check - no results to test")
+        setResultsStatus("no results")
+        setResultsList([])
       } else {
-        setResultsList((prevResultsList) => [...prevResultsList, ...data.tunes])
-        console.log("Just loaded another page of results")
+        console.log(
+          "Not performing check - no key filter, or results size threshold not exceeded"
+        )
+        setResultsStatus("results found")
+        dealWithresults(data)
       }
     },
-    [page, setResultsList]
+    [filters, dealWithresults, setResultsList]
   )
 
   useEffect(() => {
-    const filterString = `type=${filters.type}&mode=${
-      filters.mode.key
-        ? filters.mode.key + (filters.mode.modeType || "major")
-        : ""
-    }&q=${filters.q}`
-    console.group('Filter settings:')
-    console.log('filters.type', filters.type)
-    console.log('filters.mode.key', filters.mode.key)
-    console.log('filters.mode.modeType', filters.mode.modeType)
-    console.log('filters.q', filters.q)
-    console.log('filterString', filterString)
-    console.groupEnd()
+    // const filterString = `type=${filters.type}&mode=${
+    //   filters.mode.key
+    //     ? filters.mode.key + (filters.mode.modeType || "major")
+    //     : ""
+    // }&q=${filters.q}`
     const url = `https://thesession.org/tunes/search?${filterString}&perpage=20&page=${page}&format=json`
-    console.log("A1. about to send filtered API call")
+    console.log(`A1. API call:`, url)
     setResultsStatus("searching")
     fetch(url)
-      .then((response) => {
-        console.log("A2. got filtered API response", response)
-        return response.json()
-      })
+      .then((response) => response.json())
       .then((data) => {
-        console.log('API data received:', data)
-        if (
-          (filters.type || filters.mode.key || filters.q) &&
-          data.total > 1000
-        ) {
-          setResultsStatus("checking results")
-          /* Check if number of results equals the size of the given request 
-            without any key/mode filtering.
-            (If it does, the server found NO RESULTS for the given filters) */
-          const testString = `type=${filters.type}&q=${filters.q}`
-          const entireArchiveUrl =
-            `https://thesession.org/tunes/search?${testString}&format=json`
-          console.log(
-            "B1. >1000 filtered results. About to send unfiltered API call"
-          )
-          fetch(entireArchiveUrl)
-            .then((entireArchive) => {
-              console.log("B2. got un-filtered API response")
-              return entireArchive.json()
-            })
-            .then((entireArchiveData) => {
-              console.log("Setting archiveSize to:", entireArchiveData.total)
-              console.log("Filtered results list size:", data.total)
-              if (data.total >= entireArchiveData.total) {
-                console.log(
-                  "B3. No results found. Filtered list is same size as entire archive"
-                )
-                setResultsStatus("no results")
-                setResultsList([])
-                console.log("B3. resultsList has been set to EMPTY LIST")
-              } else {
-                dealWithresults(data)
-              }
-            })
-        } else if (data.total === 0) {
-          console.log("B4. No results returned from server")
-          setResultsStatus("no results")
-          setResultsList([])
-        } else {
-          dealWithresults(data)
-        }
+        checkResults(data)
       })
       .catch((error) => {
         console.log("error caught on HomePage:", error)
       })
-  }, [page, setResultsList, filters, dealWithresults])
+  }, [page, filters, filterString, checkResults])
 
   return (
     <div className="HomePage">
@@ -131,6 +180,8 @@ export default function HomePage({
           setFilters={setFilters}
           setResultsList={setResultsList}
           setPage={setPage}
+          userPrefs={userPrefs}
+          setUserPrefs={setUserPrefs}
         />
       )}
 
@@ -140,10 +191,9 @@ export default function HomePage({
         ) > -1 && <p>Searching...</p>}
         {resultsStatus === "results found" && (
           <p>
-            {(filters.type !== "" || filters.mode.key !== "" || filters.q !== "") 
-              ? ("Found " + totalResults + " ") 
-              : ("Showing all " + totalResults + " ")
-            }
+            {filters.type !== "" || filters.mode.key !== "" || filters.q !== ""
+              ? "Found " + totalResults + " "
+              : "Showing all " + totalResults + " "}
             {filters.type ? Pluralize(filters.type, 2) : "tunes"}
             {filters.mode.key &&
               " with settings in " +
@@ -175,16 +225,25 @@ export default function HomePage({
         </div>
       )}
 
-      <InfiniteScroll
+      {/* <InfiniteScroll
         dataLength={resultsList.length}
-        next={() => setPage(page + 1)}
+        next={() => {
+          console.log(`---- InfiniteScroll requesting page #${page + 1} ----`)
+          setPage(page + 1)
+        }}
         hasMore={page < totalPages}
-        loader={resultsStatus !== "no results" && page < totalPages && <div
-          className="d-flex align-items-center justify-content-center"
-          style={{ height: "100px" }}
-        >
-          <PulseLoader />
-        </div>}
+        loader={
+          resultsStatus !== "no results" &&
+          page < totalPages && (
+            <div
+              key="loader"
+              className="d-flex align-items-center justify-content-center"
+              style={{ height: "100px" }}
+            >
+              <PulseLoader />
+            </div>
+          )
+        }
         endMessage={
           <p className="end-of-results" style={{ textAlign: "center" }}>
             <b>
@@ -192,27 +251,30 @@ export default function HomePage({
             </b>
           </p>
         }
-      >
-        <div className="results">
-          {resultsList.map((tune) => (
-            <TuneResult
-              key={tune.id}
-              id={tune.id}
-              title={tune.name}
-              popularity={tune.tunebooks}
-              tuneType={tune.type}
-              date={tune.date}
-              tuneBook={tuneBook}
-              toggleTuneBookEntry={toggleTuneBookEntry}
-              filters={filters}
-              setFilters={setFilters}
-              setResultsList={setResultsList}
-              setPage={setPage}
-            />
-          ))}
-        </div>
-      </InfiniteScroll>
+      > */}
 
+      <div className="results">
+        {resultsList.map((tune) => (
+          <TuneResult
+            tune={tune}
+            key={tune.id}
+            tuneBook={tuneBook}
+            toggleTuneBookEntry={toggleTuneBookEntry}
+            filters={filters}
+            setFilters={setFilters}
+            setResultsList={setResultsList}
+            setPage={setPage}
+          />
+        ))}
+      </div>
+
+      <p className="end-of-results" style={{ textAlign: "center" }}>
+        <b>
+          Page {page} of {totalPages}. Showing {resultsList.length} out of {totalResults} tunes found
+        </b>
+      </p>
+
+      {/* </InfiniteScroll> */}
     </div>
   )
 }

--- a/src/components/HomePage/HomePage.js
+++ b/src/components/HomePage/HomePage.js
@@ -1,9 +1,10 @@
 import Pluralize from "pluralize"
-import { useState, useEffect } from "react"
+import { useState, useEffect, useCallback } from "react"
 import InfiniteScroll from "react-infinite-scroll-component"
 import ExpandMoreIcon from "@mui/icons-material/ExpandMore"
 import ExpandLessIcon from "@mui/icons-material/ExpandLess"
 import ClearIcon from "@mui/icons-material/Clear"
+import PulseLoader from "react-spinners/PulseLoader"
 
 import FilterSelect from "../FilterSelect/FilterSelect"
 import TuneResult from "../TuneResult/TuneResult"
@@ -20,8 +21,27 @@ export default function HomePage({
   const [totalPages, setTotalPages] = useState(0)
   const [totalResults, setTotalResults] = useState(0)
   const [page, setPage] = useState(1)
+  // resultsStatus can be 'initialising', 'searching', 'checking results', 'results found' or 'no results'
+  const [resultsStatus, setResultsStatus] = useState("initialising")
   const [showFilterOptions, setShowFilterOptions] = useState(false)
   Pluralize.addPluralRule(/waltz/i, "waltzes") // 🙄
+
+  const dealWithresults = useCallback(
+    (data) => {
+      console.log("DEALING WITH VALID RESULTS")
+      setResultsStatus("results found")
+      setTotalPages(data.pages)
+      setTotalResults(data.total)
+      if (page === 1) {
+        setResultsList(data.tunes)
+        console.log("Just loaded first page of results")
+      } else {
+        setResultsList((prevResultsList) => [...prevResultsList, ...data.tunes])
+        console.log("Just loaded another page of results")
+      }
+    },
+    [page, setResultsList]
+  )
 
   useEffect(() => {
     const filterString = `type=${filters.type}&mode=${
@@ -29,50 +49,72 @@ export default function HomePage({
         ? filters.mode.key + (filters.mode.modeType || "major")
         : ""
     }&q=${filters.q}`
+    console.group('Filter settings:')
+    console.log('filters.type', filters.type)
+    console.log('filters.mode.key', filters.mode.key)
+    console.log('filters.mode.modeType', filters.mode.modeType)
+    console.log('filters.q', filters.q)
+    console.log('filterString', filterString)
+    console.groupEnd()
     const url = `https://thesession.org/tunes/search?${filterString}&perpage=20&page=${page}&format=json`
-    let noResults = false
+    console.log("A1. about to send filtered API call")
+    setResultsStatus("searching")
     fetch(url)
-      .then((response) => response.json())
+      .then((response) => {
+        console.log("A2. got filtered API response", response)
+        return response.json()
+      })
       .then((data) => {
-        const numFilteredResults = data.total
-        if (numFilteredResults > 1000) {
-          /* Check if number of results equals the size of the entire archive
-            (this means the server found NO RESULTS for the given filters) */
+        console.log('API data received:', data)
+        if (
+          (filters.type || filters.mode.key || filters.q) &&
+          data.total > 1000
+        ) {
+          setResultsStatus("checking results")
+          /* Check if number of results equals the size of the given request 
+            without any key/mode filtering.
+            (If it does, the server found NO RESULTS for the given filters) */
+          const testString = `type=${filters.type}&q=${filters.q}`
           const entireArchiveUrl =
-            "https://thesession.org/tunes/search?format=json"
+            `https://thesession.org/tunes/search?${testString}&format=json`
+          console.log(
+            "B1. >1000 filtered results. About to send unfiltered API call"
+          )
           fetch(entireArchiveUrl)
-            .then((entireArchive) => entireArchive.json())
-            .then((entireArchiveData) => {
-              console.log("Entire archive size is:", entireArchiveData.total)
-              console.log("Size of filtered results is:", numFilteredResults)
-              noResults =
-                numFilteredResults === entireArchiveData.total &&
-                (filters.type || filters.mode.key || filters.q)
-              console.log(noResults 
-                ? 'NO RESULTS' 
-                : filters.type || filters.mode.key || filters.q
-                  ? 'Found some results with filters set'
-                  : 'Showing entire archive')
+            .then((entireArchive) => {
+              console.log("B2. got un-filtered API response")
+              return entireArchive.json()
             })
-        }
-        setTotalPages(numFilteredResults)
-        setTotalResults(data.total)
-        if (page === 1) {
-          setResultsList(data.tunes)
+            .then((entireArchiveData) => {
+              console.log("Setting archiveSize to:", entireArchiveData.total)
+              console.log("Filtered results list size:", data.total)
+              if (data.total >= entireArchiveData.total) {
+                console.log(
+                  "B3. No results found. Filtered list is same size as entire archive"
+                )
+                setResultsStatus("no results")
+                setResultsList([])
+                console.log("B3. resultsList has been set to EMPTY LIST")
+              } else {
+                dealWithresults(data)
+              }
+            })
+        } else if (data.total === 0) {
+          console.log("B4. No results returned from server")
+          setResultsStatus("no results")
+          setResultsList([])
         } else {
-          setResultsList((prevResultsList) => [
-            ...prevResultsList,
-            ...data.tunes,
-          ])
+          dealWithresults(data)
         }
       })
       .catch((error) => {
         console.log("error caught on HomePage:", error)
       })
-  }, [page, setResultsList, filters])
+  }, [page, setResultsList, filters, dealWithresults])
 
   return (
     <div className="HomePage">
+      {resultsStatus}
       <div className="discover-header">
         <h2>Discover tunes</h2>
         <button
@@ -93,19 +135,24 @@ export default function HomePage({
       )}
 
       <div className="filters-verbose d-flex">
-        <p>
-          {(filters.type !== "" ||
-            filters.mode.key !== "" ||
-            filters.q !== "") &&
-            "Filtered results: "}
-          {"Found " + totalResults + " "}
-          {filters.type ? Pluralize(filters.type, 2) : "tunes"}
-          {filters.mode.key &&
-            " with settings in " +
-              filters.mode.key +
-              " " +
-              (filters.mode.modeType || "major")}
-        </p>
+        {["initialising", "searching", "checking results"].indexOf(
+          resultsStatus
+        ) > -1 && <p>Searching...</p>}
+        {resultsStatus === "results found" && (
+          <p>
+            {(filters.type !== "" || filters.mode.key !== "" || filters.q !== "") 
+              ? ("Found " + totalResults + " ") 
+              : ("Showing all " + totalResults + " ")
+            }
+            {filters.type ? Pluralize(filters.type, 2) : "tunes"}
+            {filters.mode.key &&
+              " with settings in " +
+                filters.mode.key +
+                " " +
+                (filters.mode.modeType || "major")}
+          </p>
+        )}
+        {resultsStatus === "no results" && <p>No results</p>}
       </div>
 
       {(filters.type !== "" || filters.mode.key !== "" || filters.q !== "") && (
@@ -132,7 +179,12 @@ export default function HomePage({
         dataLength={resultsList.length}
         next={() => setPage(page + 1)}
         hasMore={page < totalPages}
-        loader={<h4>Loading...</h4>}
+        loader={resultsStatus !== "no results" && page < totalPages && <div
+          className="d-flex align-items-center justify-content-center"
+          style={{ height: "100px" }}
+        >
+          <PulseLoader />
+        </div>}
         endMessage={
           <p className="end-of-results" style={{ textAlign: "center" }}>
             <b>
@@ -160,6 +212,7 @@ export default function HomePage({
           ))}
         </div>
       </InfiniteScroll>
+
     </div>
   )
 }

--- a/src/components/HomePage/HomePage.js
+++ b/src/components/HomePage/HomePage.js
@@ -30,10 +30,32 @@ export default function HomePage({
         : ""
     }&q=${filters.q}`
     const url = `https://thesession.org/tunes/search?${filterString}&perpage=20&page=${page}&format=json`
+    let noResults = false
     fetch(url)
       .then((response) => response.json())
       .then((data) => {
-        setTotalPages(data.pages)
+        const numFilteredResults = data.total
+        if (numFilteredResults > 1000) {
+          /* Check if number of results equals the size of the entire archive
+            (this means the server found NO RESULTS for the given filters) */
+          const entireArchiveUrl =
+            "https://thesession.org/tunes/search?format=json"
+          fetch(entireArchiveUrl)
+            .then((entireArchive) => entireArchive.json())
+            .then((entireArchiveData) => {
+              console.log("Entire archive size is:", entireArchiveData.total)
+              console.log("Size of filtered results is:", numFilteredResults)
+              noResults =
+                numFilteredResults === entireArchiveData.total &&
+                (filters.type || filters.mode.key || filters.q)
+              console.log(noResults 
+                ? 'NO RESULTS' 
+                : filters.type || filters.mode.key || filters.q
+                  ? 'Found some results with filters set'
+                  : 'Showing entire archive')
+            })
+        }
+        setTotalPages(numFilteredResults)
         setTotalResults(data.total)
         if (page === 1) {
           setResultsList(data.tunes)

--- a/src/components/HomePage/debug.LOG
+++ b/src/components/HomePage/debug.LOG
@@ -1,0 +1,2848 @@
+HomePage.js:122 A1. API call: https://thesession.org/tunes/search?type=&mode=&q=&perpage=20&page=1&format=json
+HomePage.js:73 checkResults() called
+HomePage.js:105 Not performing check - no key filter, or threshold not exceeded
+HomePage.js:31 dealWithResults() called
+HomePage.js:40 Getting data for tune # 27
+HomePage.js:40 Getting data for tune # 55
+HomePage.js:40 Getting data for tune # 1
+HomePage.js:40 Getting data for tune # 10
+HomePage.js:40 Getting data for tune # 71
+HomePage.js:40 Getting data for tune # 182
+HomePage.js:40 Getting data for tune # 64
+HomePage.js:40 Getting data for tune # 8
+HomePage.js:40 Getting data for tune # 9
+HomePage.js:40 Getting data for tune # 108
+HomePage.js:40 Getting data for tune # 116
+HomePage.js:40 Getting data for tune # 248
+HomePage.js:40 Getting data for tune # 73
+HomePage.js:40 Getting data for tune # 19
+HomePage.js:40 Getting data for tune # 83
+HomePage.js:40 Getting data for tune # 5
+HomePage.js:40 Getting data for tune # 475
+HomePage.js:40 Getting data for tune # 49
+HomePage.js:40 Getting data for tune # 52
+HomePage.js:40 Getting data for tune # 42
+HomePage.js:45 Data for tune #27 {format: 'json', id: 27, name: 'Drowsy Maggie', url: 'https://thesession.org/tunes/27', member: {…}, …}
+HomePage.js:45 Data for tune #55 {format: 'json', id: 55, name: 'The Kesh', url: 'https://thesession.org/tunes/55', member: {…}, …}
+HomePage.js:45 Data for tune #182 {format: 'json', id: 182, name: 'The Silver Spear', url: 'https://thesession.org/tunes/182', member: {…}, …}
+HomePage.js:45 Data for tune #64 {format: 'json', id: 64, name: 'The Maid Behind The Bar', url: 'https://thesession.org/tunes/64', member: {…}, …}
+HomePage.js:45 Data for tune #8 {format: 'json', id: 8, name: 'The Banshee', url: 'https://thesession.org/tunes/8', member: {…}, …}
+HomePage.js:45 Data for tune #71 {format: 'json', id: 71, name: "Morrison's", url: 'https://thesession.org/tunes/71', member: {…}, …}
+HomePage.js:45 Data for tune #1 {format: 'json', id: 1, name: "Cooley's", url: 'https://thesession.org/tunes/1', member: {…}, …}
+HomePage.js:45 Data for tune #10 {format: 'json', id: 10, name: 'The Butterfly', url: 'https://thesession.org/tunes/10', member: {…}, …}
+HomePage.js:45 Data for tune #9 {format: 'json', id: 9, name: 'Banish Misfortune', url: 'https://thesession.org/tunes/9', member: {…}, …}
+HomePage.js:45 Data for tune #108 {format: 'json', id: 108, name: 'Out On The Ocean', url: 'https://thesession.org/tunes/108', member: {…}, …}
+HomePage.js:45 Data for tune #116 {format: 'json', id: 116, name: 'The Wind That Shakes The Barley', url: 'https://thesession.org/tunes/116', member: {…}, …}
+HomePage.js:45 Data for tune #73 {format: 'json', id: 73, name: 'The Musical Priest', url: 'https://thesession.org/tunes/73', member: {…}, …}
+HomePage.js:45 Data for tune #19 {format: 'json', id: 19, name: "The Connaughtman's Rambles", url: 'https://thesession.org/tunes/19', member: {…}, …}
+HomePage.js:45 Data for tune #83 {format: 'json', id: 83, name: 'The Rights Of Man', url: 'https://thesession.org/tunes/83', member: {…}, …}
+HomePage.js:45 Data for tune #248 {format: 'json', id: 248, name: 'Tam Lin', url: 'https://thesession.org/tunes/248', member: {…}, …}
+HomePage.js:45 Data for tune #5 {format: 'json', id: 5, name: 'The Blarney Pilgrim', url: 'https://thesession.org/tunes/5', member: {…}, …}
+HomePage.js:45 Data for tune #475 {format: 'json', id: 475, name: 'King Of The Fairies', url: 'https://thesession.org/tunes/475', member: {…}, …}
+HomePage.js:45 Data for tune #49 {format: 'json', id: 49, name: 'The Harvest Home', url: 'https://thesession.org/tunes/49', member: {…}, …}
+HomePage.js:45 Data for tune #52 {format: 'json', id: 52, name: 'The Kid On The Mountain', url: 'https://thesession.org/tunes/52', member: {…}, …}
+HomePage.js:45 Data for tune #42 {format: 'json', id: 42, name: 'The Gravel Walks', url: 'https://thesession.org/tunes/42', member: {…}, …}
+HomePage.js:199 ---- InfiniteScroll requesting page #2 ----
+HomePage.js:122 A1. API call: https://thesession.org/tunes/search?type=&mode=&q=&perpage=20&page=2&format=json
+HomePage.js:73 checkResults() called
+HomePage.js:105 Not performing check - no key filter, or threshold not exceeded
+HomePage.js:31 dealWithResults() called
+HomePage.js:40 Getting data for tune # 106
+HomePage.js:40 Getting data for tune # 74
+HomePage.js:40 Getting data for tune # 98
+HomePage.js:40 Getting data for tune # 60
+HomePage.js:40 Getting data for tune # 449
+HomePage.js:40 Getting data for tune # 62
+HomePage.js:40 Getting data for tune # 68
+HomePage.js:40 Getting data for tune # 103
+HomePage.js:40 Getting data for tune # 651
+HomePage.js:40 Getting data for tune # 12
+HomePage.js:40 Getting data for tune # 15
+HomePage.js:40 Getting data for tune # 197
+HomePage.js:40 Getting data for tune # 72
+HomePage.js:40 Getting data for tune # 20
+HomePage.js:40 Getting data for tune # 208
+HomePage.js:40 Getting data for tune # 30
+HomePage.js:40 Getting data for tune # 111
+HomePage.js:40 Getting data for tune # 69
+HomePage.js:40 Getting data for tune # 113
+HomePage.js:40 Getting data for tune # 2
+HomePage.js:45 Data for tune #106 {format: 'json', id: 106, name: 'The Swallowtail', url: 'https://thesession.org/tunes/106', member: {…}, …}
+HomePage.js:45 Data for tune #68 {format: 'json', id: 68, name: 'The Mountain Road', url: 'https://thesession.org/tunes/68', member: {…}, …}
+HomePage.js:45 Data for tune #98 {format: 'json', id: 98, name: 'The Sally Gardens', url: 'https://thesession.org/tunes/98', member: {…}, …}
+HomePage.js:45 Data for tune #60 {format: 'json', id: 60, name: 'The Lilting Banshee', url: 'https://thesession.org/tunes/60', member: {…}, …}
+HomePage.js:45 Data for tune #62 {format: 'json', id: 62, name: 'The Lark In The Morning', url: 'https://thesession.org/tunes/62', member: {…}, …}
+HomePage.js:45 Data for tune #103 {format: 'json', id: 103, name: "Saint Anne's", url: 'https://thesession.org/tunes/103', member: {…}, …}
+HomePage.js:45 Data for tune #449 {format: 'json', id: 449, name: 'Sí Beag Sí Mór', url: 'https://thesession.org/tunes/449', member: {…}, …}
+HomePage.js:45 Data for tune #651 {format: 'json', id: 651, name: 'The Boys Of Bluehill', url: 'https://thesession.org/tunes/651', member: {…}, …}
+HomePage.js:45 Data for tune #12 {format: 'json', id: 12, name: 'The Cliffs Of Moher', url: 'https://thesession.org/tunes/12', member: {…}, …}
+HomePage.js:45 Data for tune #15 {format: 'json', id: 15, name: 'Calliope House', url: 'https://thesession.org/tunes/15', member: {…}, …}
+HomePage.js:45 Data for tune #74 {format: 'json', id: 74, name: "The Mason's Apron", url: 'https://thesession.org/tunes/74', member: {…}, …}
+HomePage.js:45 Data for tune #197 {format: 'json', id: 197, name: 'The Star Of Munster', url: 'https://thesession.org/tunes/197', member: {…}, …}
+HomePage.js:45 Data for tune #72 {format: 'json', id: 72, name: 'The Merry Blacksmith', url: 'https://thesession.org/tunes/72', member: {…}, …}
+HomePage.js:45 Data for tune #20 {format: 'json', id: 20, name: 'The Cup Of Tea', url: 'https://thesession.org/tunes/20', member: {…}, …}
+HomePage.js:45 Data for tune #208 {format: 'json', id: 208, name: 'The Congress', url: 'https://thesession.org/tunes/208', member: {…}, …}
+HomePage.js:45 Data for tune #30 {format: 'json', id: 30, name: 'Off To California', url: 'https://thesession.org/tunes/30', member: {…}, …}
+HomePage.js:45 Data for tune #111 {format: 'json', id: 111, name: 'Tripping Up The Stairs', url: 'https://thesession.org/tunes/111', member: {…}, …}
+HomePage.js:45 Data for tune #69 {format: 'json', id: 69, name: 'The Morning Dew', url: 'https://thesession.org/tunes/69', member: {…}, …}
+HomePage.js:45 Data for tune #113 {format: 'json', id: 113, name: 'Toss The Feathers', url: 'https://thesession.org/tunes/113', member: {…}, …}
+HomePage.js:45 Data for tune #2 {format: 'json', id: 2, name: 'The Bucks Of Oranmore', url: 'https://thesession.org/tunes/2', member: {…}, …}
+HomePage.js:199 ---- InfiniteScroll requesting page #3 ----
+HomePage.js:122 A1. API call: https://thesession.org/tunes/search?type=&mode=&q=&perpage=20&page=3&format=json
+HomePage.js:73 checkResults() called
+HomePage.js:105 Not performing check - no key filter, or threshold not exceeded
+HomePage.js:31 dealWithResults() called
+HomePage.js:40 Getting data for tune # 211
+HomePage.js:40 Getting data for tune # 92
+HomePage.js:40 Getting data for tune # 118
+HomePage.js:40 Getting data for tune # 441
+HomePage.js:40 Getting data for tune # 75
+HomePage.js:40 Getting data for tune # 750
+HomePage.js:40 Getting data for tune # 517
+HomePage.js:40 Getting data for tune # 250
+HomePage.js:40 Getting data for tune # 76
+HomePage.js:40 Getting data for tune # 702
+HomePage.js:40 Getting data for tune # 221
+HomePage.js:40 Getting data for tune # 1075
+HomePage.js:40 Getting data for tune # 566
+HomePage.js:40 Getting data for tune # 256
+HomePage.js:40 Getting data for tune # 67
+HomePage.js:40 Getting data for tune # 589
+HomePage.js:40 Getting data for tune # 593
+HomePage.js:40 Getting data for tune # 582
+HomePage.js:40 Getting data for tune # 70
+HomePage.js:40 Getting data for tune # 141
+HomePage.js:45 Data for tune #211 {format: 'json', id: 211, name: 'Inisheer', url: 'https://thesession.org/tunes/211', member: {…}, …}
+HomePage.js:199 ---- InfiniteScroll requesting page #4 ----
+HomePage.js:122 A1. API call: https://thesession.org/tunes/search?type=&mode=&q=&perpage=20&page=4&format=json
+HomePage.js:45 Data for tune #517 {format: 'json', id: 517, name: 'The Pigeon On The Gate', url: 'https://thesession.org/tunes/517', member: {…}, …}
+HomePage.js:199 ---- InfiniteScroll requesting page #5 ----
+HomePage.js:122 A1. API call: https://thesession.org/tunes/search?type=&mode=&q=&perpage=20&page=5&format=json
+HomePage.js:45 Data for tune #441 {format: 'json', id: 441, name: "John Ryan's", url: 'https://thesession.org/tunes/441', member: {…}, …}
+HomePage.js:45 Data for tune #118 {format: 'json', id: 118, name: 'The Wise Maid', url: 'https://thesession.org/tunes/118', member: {…}, …}
+HomePage.js:45 Data for tune #750 {format: 'json', id: 750, name: 'A Fig For A Kiss', url: 'https://thesession.org/tunes/750', member: {…}, …}
+HomePage.js:199 ---- InfiniteScroll requesting page #6 ----
+HomePage.js:122 A1. API call: https://thesession.org/tunes/search?type=&mode=&q=&perpage=20&page=6&format=json
+HomePage.js:45 Data for tune #92 {format: 'json', id: 92, name: 'The Irish Washerwoman', url: 'https://thesession.org/tunes/92', member: {…}, …}
+HomePage.js:45 Data for tune #75 {format: 'json', id: 75, name: "Miss McLeod's", url: 'https://thesession.org/tunes/75', member: {…}, …}
+HomePage.js:199 ---- InfiniteScroll requesting page #7 ----
+HomePage.js:122 A1. API call: https://thesession.org/tunes/search?type=&mode=&q=&perpage=20&page=7&format=json
+HomePage.js:45 Data for tune #702 {format: 'json', id: 702, name: 'The Blackthorn Stick', url: 'https://thesession.org/tunes/702', member: {…}, …}
+HomePage.js:45 Data for tune #76 {format: 'json', id: 76, name: 'My Darling Asleep', url: 'https://thesession.org/tunes/76', member: {…}, …}
+HomePage.js:45 Data for tune #221 {format: 'json', id: 221, name: "The Earl's Chair", url: 'https://thesession.org/tunes/221', member: {…}, …}
+HomePage.js:45 Data for tune #250 {format: 'json', id: 250, name: 'The Road To Lisdoonvarna', url: 'https://thesession.org/tunes/250', member: {…}, …}
+HomePage.js:199 ---- InfiniteScroll requesting page #8 ----
+HomePage.js:122 A1. API call: https://thesession.org/tunes/search?type=&mode=&q=&perpage=20&page=8&format=json
+HomePage.js:45 Data for tune #1075 {format: 'json', id: 1075, name: 'The Britches Full Of Stitches', url: 'https://thesession.org/tunes/1075', member: {…}, …}
+HomePage.js:199 ---- InfiniteScroll requesting page #9 ----
+HomePage.js:122 A1. API call: https://thesession.org/tunes/search?type=&mode=&q=&perpage=20&page=9&format=json
+HomePage.js:45 Data for tune #566 {format: 'json', id: 566, name: 'The Little Beggarman', url: 'https://thesession.org/tunes/566', member: {…}, …}
+HomePage.js:45 Data for tune #67 {format: 'json', id: 67, name: 'The Monaghan', url: 'https://thesession.org/tunes/67', member: {…}, …}
+HomePage.js:45 Data for tune #589 {format: 'json', id: 589, name: "Julia Delaney's", url: 'https://thesession.org/tunes/589', member: {…}, …}
+HomePage.js:45 Data for tune #593 {format: 'json', id: 593, name: 'The Rocky Road To Dublin', url: 'https://thesession.org/tunes/593', member: {…}, …}
+HomePage.js:199 ---- InfiniteScroll requesting page #10 ----
+HomePage.js:122 A1. API call: https://thesession.org/tunes/search?type=&mode=&q=&perpage=20&page=10&format=json
+HomePage.js:45 Data for tune #582 {format: 'json', id: 582, name: 'Haste To The Wedding', url: 'https://thesession.org/tunes/582', member: {…}, …}
+HomePage.js:45 Data for tune #256 {format: 'json', id: 256, name: 'The Mist Covered Mountain', url: 'https://thesession.org/tunes/256', member: {…}, …}
+HomePage.js:45 Data for tune #70 {format: 'json', id: 70, name: 'Merrily Kissed The Quaker', url: 'https://thesession.org/tunes/70', member: {…}, …}
+HomePage.js:45 Data for tune #141 {format: 'json', id: 141, name: 'The Humours Of Tulla', url: 'https://thesession.org/tunes/141', member: {…}, …}
+HomePage.js:199 ---- InfiniteScroll requesting page #11 ----
+HomePage.js:122 A1. API call: https://thesession.org/tunes/search?type=&mode=&q=&perpage=20&page=11&format=json
+HomePage.js:73 checkResults() called
+HomePage.js:105 Not performing check - no key filter, or threshold not exceeded
+HomePage.js:31 dealWithResults() called
+HomePage.js:40 Getting data for tune # 240
+HomePage.js:40 Getting data for tune # 299
+HomePage.js:40 Getting data for tune # 120
+HomePage.js:40 Getting data for tune # 342
+HomePage.js:40 Getting data for tune # 104
+HomePage.js:40 Getting data for tune # 271
+HomePage.js:40 Getting data for tune # 310
+HomePage.js:40 Getting data for tune # 24
+HomePage.js:40 Getting data for tune # 629
+HomePage.js:40 Getting data for tune # 1076
+HomePage.js:40 Getting data for tune # 236
+HomePage.js:40 Getting data for tune # 775
+HomePage.js:40 Getting data for tune # 85
+HomePage.js:40 Getting data for tune # 134
+HomePage.js:40 Getting data for tune # 249
+HomePage.js:40 Getting data for tune # 828
+HomePage.js:40 Getting data for tune # 34
+HomePage.js:40 Getting data for tune # 77
+HomePage.js:40 Getting data for tune # 321
+HomePage.js:40 Getting data for tune # 515
+HomePage.js:73 checkResults() called
+HomePage.js:105 Not performing check - no key filter, or threshold not exceeded
+HomePage.js:31 dealWithResults() called
+HomePage.js:40 Getting data for tune # 560
+HomePage.js:40 Getting data for tune # 399
+HomePage.js:40 Getting data for tune # 447
+HomePage.js:40 Getting data for tune # 4997
+HomePage.js:40 Getting data for tune # 114
+HomePage.js:40 Getting data for tune # 87
+HomePage.js:40 Getting data for tune # 138
+HomePage.js:40 Getting data for tune # 26
+HomePage.js:40 Getting data for tune # 430
+HomePage.js:40 Getting data for tune # 43
+HomePage.js:40 Getting data for tune # 89
+HomePage.js:40 Getting data for tune # 88
+HomePage.js:40 Getting data for tune # 115
+HomePage.js:40 Getting data for tune # 432
+HomePage.js:40 Getting data for tune # 188
+HomePage.js:40 Getting data for tune # 18
+HomePage.js:40 Getting data for tune # 105
+HomePage.js:40 Getting data for tune # 726
+HomePage.js:40 Getting data for tune # 109
+HomePage.js:40 Getting data for tune # 99
+HomePage.js:73 checkResults() called
+HomePage.js:105 Not performing check - no key filter, or threshold not exceeded
+HomePage.js:31 dealWithResults() called
+HomePage.js:40 Getting data for tune # 602
+HomePage.js:40 Getting data for tune # 440
+HomePage.js:40 Getting data for tune # 84
+HomePage.js:40 Getting data for tune # 238
+HomePage.js:40 Getting data for tune # 703
+HomePage.js:40 Getting data for tune # 857
+HomePage.js:40 Getting data for tune # 5270
+HomePage.js:40 Getting data for tune # 410
+HomePage.js:40 Getting data for tune # 56
+HomePage.js:40 Getting data for tune # 363
+HomePage.js:40 Getting data for tune # 44
+HomePage.js:40 Getting data for tune # 151
+HomePage.js:40 Getting data for tune # 91
+HomePage.js:40 Getting data for tune # 448
+HomePage.js:40 Getting data for tune # 335
+HomePage.js:40 Getting data for tune # 2221
+HomePage.js:40 Getting data for tune # 357
+HomePage.js:40 Getting data for tune # 53
+HomePage.js:40 Getting data for tune # 160
+HomePage.js:40 Getting data for tune # 382
+HomePage.js:73 checkResults() called
+HomePage.js:105 Not performing check - no key filter, or threshold not exceeded
+HomePage.js:31 dealWithResults() called
+HomePage.js:40 Getting data for tune # 793
+HomePage.js:40 Getting data for tune # 29
+HomePage.js:40 Getting data for tune # 727
+HomePage.js:40 Getting data for tune # 511
+HomePage.js:40 Getting data for tune # 33
+HomePage.js:40 Getting data for tune # 39
+HomePage.js:40 Getting data for tune # 482
+HomePage.js:40 Getting data for tune # 307
+HomePage.js:40 Getting data for tune # 107
+HomePage.js:40 Getting data for tune # 636
+HomePage.js:40 Getting data for tune # 21
+HomePage.js:40 Getting data for tune # 543
+HomePage.js:40 Getting data for tune # 462
+HomePage.js:40 Getting data for tune # 86
+HomePage.js:40 Getting data for tune # 544
+HomePage.js:40 Getting data for tune # 454
+HomePage.js:40 Getting data for tune # 35
+HomePage.js:40 Getting data for tune # 222
+HomePage.js:40 Getting data for tune # 381
+HomePage.js:40 Getting data for tune # 518
+HomePage.js:73 checkResults() called
+HomePage.js:105 Not performing check - no key filter, or threshold not exceeded
+HomePage.js:31 dealWithResults() called
+HomePage.js:40 Getting data for tune # 45
+HomePage.js:40 Getting data for tune # 605
+HomePage.js:40 Getting data for tune # 756
+HomePage.js:40 Getting data for tune # 346
+HomePage.js:40 Getting data for tune # 601
+HomePage.js:40 Getting data for tune # 957
+HomePage.js:40 Getting data for tune # 219
+HomePage.js:40 Getting data for tune # 210
+HomePage.js:40 Getting data for tune # 646
+HomePage.js:40 Getting data for tune # 562
+HomePage.js:40 Getting data for tune # 829
+HomePage.js:40 Getting data for tune # 2410
+HomePage.js:40 Getting data for tune # 570
+HomePage.js:40 Getting data for tune # 139
+HomePage.js:40 Getting data for tune # 2549
+HomePage.js:40 Getting data for tune # 790
+HomePage.js:40 Getting data for tune # 791
+HomePage.js:40 Getting data for tune # 1292
+HomePage.js:40 Getting data for tune # 308
+HomePage.js:40 Getting data for tune # 4320
+HomePage.js:73 checkResults() called
+HomePage.js:105 Not performing check - no key filter, or threshold not exceeded
+HomePage.js:31 dealWithResults() called
+HomePage.js:40 Getting data for tune # 476
+HomePage.js:40 Getting data for tune # 1499
+HomePage.js:40 Getting data for tune # 81
+HomePage.js:40 Getting data for tune # 291
+HomePage.js:40 Getting data for tune # 879
+HomePage.js:40 Getting data for tune # 891
+HomePage.js:40 Getting data for tune # 11
+HomePage.js:40 Getting data for tune # 496
+HomePage.js:40 Getting data for tune # 1977
+HomePage.js:40 Getting data for tune # 13
+HomePage.js:40 Getting data for tune # 48
+HomePage.js:40 Getting data for tune # 388
+HomePage.js:40 Getting data for tune # 788
+HomePage.js:40 Getting data for tune # 471
+HomePage.js:40 Getting data for tune # 36
+HomePage.js:40 Getting data for tune # 477
+HomePage.js:40 Getting data for tune # 1016
+HomePage.js:40 Getting data for tune # 112
+HomePage.js:40 Getting data for tune # 1359
+HomePage.js:40 Getting data for tune # 2516
+HomePage.js:45 Data for tune #240 {format: 'json', id: 240, name: 'The Silver Spire', url: 'https://thesession.org/tunes/240', member: {…}, …}
+HomePage.js:45 Data for tune #299 {format: 'json', id: 299, name: 'Apples In Winter', url: 'https://thesession.org/tunes/299', member: {…}, …}
+HomePage.js:45 Data for tune #120 {format: 'json', id: 120, name: 'The Maids Of Mitchelstown', url: 'https://thesession.org/tunes/120', member: {…}, …}
+HomePage.js:45 Data for tune #104 {format: 'json', id: 104, name: 'The Snowy Path', url: 'https://thesession.org/tunes/104', member: {…}, …}
+HomePage.js:45 Data for tune #271 {format: 'json', id: 271, name: "Brian Boru's March", url: 'https://thesession.org/tunes/271', member: {…}, …}
+HomePage.js:45 Data for tune #342 {format: 'json', id: 342, name: "The Cat's Meow", url: 'https://thesession.org/tunes/342', member: {…}, …}
+HomePage.js:45 Data for tune #310 {format: 'json', id: 310, name: 'The Home Ruler', url: 'https://thesession.org/tunes/310', member: {…}, …}
+HomePage.js:45 Data for tune #24 {format: 'json', id: 24, name: "Dinkey's", url: 'https://thesession.org/tunes/24', member: {…}, …}
+HomePage.js:45 Data for tune #629 {format: 'json', id: 629, name: 'The Bird In The Bush', url: 'https://thesession.org/tunes/629', member: {…}, …}
+HomePage.js:45 Data for tune #1076 {format: 'json', id: 1076, name: 'The Black Rogue', url: 'https://thesession.org/tunes/1076', member: {…}, …}
+HomePage.js:45 Data for tune #236 {format: 'json', id: 236, name: 'Swinging On The Gate', url: 'https://thesession.org/tunes/236', member: {…}, …}
+HomePage.js:45 Data for tune #775 {format: 'json', id: 775, name: 'The Banks Of Lough Gowna', url: 'https://thesession.org/tunes/775', member: {…}, …}
+HomePage.js:45 Data for tune #134 {format: 'json', id: 134, name: 'The Strayaway Child', url: 'https://thesession.org/tunes/134', member: {…}, …}
+HomePage.js:73 checkResults() called
+HomePage.js:105 Not performing check - no key filter, or threshold not exceeded
+HomePage.js:31 dealWithResults() called
+HomePage.js:40 Getting data for tune # 129
+HomePage.js:40 Getting data for tune # 166
+HomePage.js:40 Getting data for tune # 1398
+HomePage.js:40 Getting data for tune # 1308
+HomePage.js:40 Getting data for tune # 733
+HomePage.js:40 Getting data for tune # 101
+HomePage.js:40 Getting data for tune # 195
+HomePage.js:40 Getting data for tune # 478
+HomePage.js:40 Getting data for tune # 423
+HomePage.js:40 Getting data for tune # 332
+HomePage.js:40 Getting data for tune # 7
+HomePage.js:40 Getting data for tune # 579
+HomePage.js:40 Getting data for tune # 1091
+HomePage.js:40 Getting data for tune # 302
+HomePage.js:40 Getting data for tune # 397
+HomePage.js:40 Getting data for tune # 5758
+HomePage.js:40 Getting data for tune # 351
+HomePage.js:40 Getting data for tune # 696
+HomePage.js:40 Getting data for tune # 634
+HomePage.js:40 Getting data for tune # 4906
+HomePage.js:45 Data for tune #85 {format: 'json', id: 85, name: 'The Rakes Of Mallow', url: 'https://thesession.org/tunes/85', member: {…}, …}
+HomePage.js:45 Data for tune #249 {format: 'json', id: 249, name: 'The Road To Lisdoonvarna', url: 'https://thesession.org/tunes/249', member: {…}, …}
+HomePage.js:73 checkResults() called
+HomePage.js:105 Not performing check - no key filter, or threshold not exceeded
+HomePage.js:31 dealWithResults() called
+HomePage.js:40 Getting data for tune # 718
+HomePage.js:40 Getting data for tune # 812
+HomePage.js:40 Getting data for tune # 667
+HomePage.js:40 Getting data for tune # 358
+HomePage.js:40 Getting data for tune # 888
+HomePage.js:40 Getting data for tune # 261
+HomePage.js:40 Getting data for tune # 467
+HomePage.js:40 Getting data for tune # 17
+HomePage.js:40 Getting data for tune # 728
+HomePage.js:40 Getting data for tune # 1055
+HomePage.js:40 Getting data for tune # 424
+HomePage.js:40 Getting data for tune # 481
+HomePage.js:40 Getting data for tune # 1356
+HomePage.js:40 Getting data for tune # 192
+HomePage.js:40 Getting data for tune # 1080
+HomePage.js:40 Getting data for tune # 93
+HomePage.js:40 Getting data for tune # 1552
+HomePage.js:40 Getting data for tune # 408
+HomePage.js:40 Getting data for tune # 58
+HomePage.js:40 Getting data for tune # 273
+HomePage.js:45 Data for tune #828 {format: 'json', id: 828, name: 'The Morning Star', url: 'https://thesession.org/tunes/828', member: {…}, …}
+HomePage.js:45 Data for tune #34 {format: 'json', id: 34, name: 'The Frieze Breeches', url: 'https://thesession.org/tunes/34', member: {…}, …}
+HomePage.js:45 Data for tune #321 {format: 'json', id: 321, name: 'The Woman Of The House', url: 'https://thesession.org/tunes/321', member: {…}, …}
+HomePage.js:45 Data for tune #515 {format: 'json', id: 515, name: 'The Rolling Waves', url: 'https://thesession.org/tunes/515', member: {…}, …}
+HomePage.js:45 Data for tune #399 {format: 'json', id: 399, name: 'The Sligo Maid', url: 'https://thesession.org/tunes/399', member: {…}, …}
+HomePage.js:45 Data for tune #77 {format: 'json', id: 77, name: 'My Love Is In America', url: 'https://thesession.org/tunes/77', member: {…}, …}
+HomePage.js:45 Data for tune #447 {format: 'json', id: 447, name: 'The Rose In The Heather', url: 'https://thesession.org/tunes/447', member: {…}, …}
+HomePage.js:45 Data for tune #560 {format: 'json', id: 560, name: 'The Tarbolton', url: 'https://thesession.org/tunes/560', member: {…}, …}
+HomePage.js:45 Data for tune #4997 {format: 'json', id: 4997, name: 'Ashokan Farewell', url: 'https://thesession.org/tunes/4997', member: {…}, …}
+HomePage.js:45 Data for tune #114 {format: 'json', id: 114, name: "The Teetotaler's", url: 'https://thesession.org/tunes/114', member: {…}, …}
+HomePage.js:45 Data for tune #87 {format: 'json', id: 87, name: 'Rolling In The Ryegrass', url: 'https://thesession.org/tunes/87', member: {…}, …}
+HomePage.js:45 Data for tune #138 {format: 'json', id: 138, name: 'Toss The Feathers', url: 'https://thesession.org/tunes/138', member: {…}, …}
+HomePage.js:45 Data for tune #26 {format: 'json', id: 26, name: 'Donnybrook Fair', url: 'https://thesession.org/tunes/26', member: {…}, …}
+HomePage.js:45 Data for tune #430 {format: 'json', id: 430, name: 'Sporting Paddy', url: 'https://thesession.org/tunes/430', member: {…}, …}
+HomePage.js:45 Data for tune #43 {format: 'json', id: 43, name: 'The Geese In The Bog', url: 'https://thesession.org/tunes/43', member: {…}, …}
+HomePage.js:45 Data for tune #89 {format: 'json', id: 89, name: 'The Rambling Pitchfork', url: 'https://thesession.org/tunes/89', member: {…}, …}
+HomePage.js:45 Data for tune #88 {format: 'json', id: 88, name: 'The Rolling Waves', url: 'https://thesession.org/tunes/88', member: {…}, …}
+HomePage.js:45 Data for tune #115 {format: 'json', id: 115, name: 'Over The Moor To Maggie', url: 'https://thesession.org/tunes/115', member: {…}, …}
+HomePage.js:45 Data for tune #432 {format: 'json', id: 432, name: 'The Maid Of Mount Kisco', url: 'https://thesession.org/tunes/432', member: {…}, …}
+HomePage.js:45 Data for tune #188 {format: 'json', id: 188, name: 'The Glass Of Beer', url: 'https://thesession.org/tunes/188', member: {…}, …}
+HomePage.js:45 Data for tune #18 {format: 'json', id: 18, name: 'The Concertina', url: 'https://thesession.org/tunes/18', member: {…}, …}
+HomePage.js:45 Data for tune #105 {format: 'json', id: 105, name: "The Swallow's Tail", url: 'https://thesession.org/tunes/105', member: {…}, …}
+HomePage.js:45 Data for tune #726 {format: 'json', id: 726, name: 'The Ashplant', url: 'https://thesession.org/tunes/726', member: {…}, …}
+HomePage.js:45 Data for tune #109 {format: 'json', id: 109, name: 'The Tenpenny Bit', url: 'https://thesession.org/tunes/109', member: {…}, …}
+HomePage.js:45 Data for tune #99 {format: 'json', id: 99, name: 'The Salamanca', url: 'https://thesession.org/tunes/99', member: {…}, …}
+HomePage.js:45 Data for tune #602 {format: 'json', id: 602, name: 'Whiskey Before Breakfast', url: 'https://thesession.org/tunes/602', member: {…}, …}
+HomePage.js:45 Data for tune #440 {format: 'json', id: 440, name: 'Christmas Eve', url: 'https://thesession.org/tunes/440', member: {…}, …}
+HomePage.js:45 Data for tune #84 {format: 'json', id: 84, name: 'The Rakes Of Kildare', url: 'https://thesession.org/tunes/84', member: {…}, …}
+HomePage.js:45 Data for tune #238 {format: 'json', id: 238, name: 'The Ballydesmond', url: 'https://thesession.org/tunes/238', member: {…}, …}
+HomePage.js:45 Data for tune #703 {format: 'json', id: 703, name: 'Catharsis', url: 'https://thesession.org/tunes/703', member: {…}, …}
+HomePage.js:45 Data for tune #857 {format: 'json', id: 857, name: 'Spootiskerry', url: 'https://thesession.org/tunes/857', member: {…}, …}
+HomePage.js:45 Data for tune #5270 {format: 'json', id: 5270, name: 'The Road To Errogie', url: 'https://thesession.org/tunes/5270', member: {…}, …}
+HomePage.js:45 Data for tune #410 {format: 'json', id: 410, name: 'The Old Copperplate', url: 'https://thesession.org/tunes/410', member: {…}, …}
+HomePage.js:45 Data for tune #56 {format: 'json', id: 56, name: 'The Old Favourite', url: 'https://thesession.org/tunes/56', member: {…}, …}
+HomePage.js:45 Data for tune #363 {format: 'json', id: 363, name: 'The Drunken Landlady', url: 'https://thesession.org/tunes/363', member: {…}, …}
+HomePage.js:45 Data for tune #44 {format: 'json', id: 44, name: 'The High', url: 'https://thesession.org/tunes/44', member: {…}, …}
+HomePage.js:45 Data for tune #151 {format: 'json', id: 151, name: 'The Tar Road To Sligo', url: 'https://thesession.org/tunes/151', member: {…}, …}
+HomePage.js:45 Data for tune #91 {format: 'json', id: 91, name: 'The Roaring Barmaid', url: 'https://thesession.org/tunes/91', member: {…}, …}
+HomePage.js:45 Data for tune #448 {format: 'json', id: 448, name: 'The Frost Is All Over', url: 'https://thesession.org/tunes/448', member: {…}, …}
+HomePage.js:45 Data for tune #335 {format: 'json', id: 335, name: 'Sliabh Russell', url: 'https://thesession.org/tunes/335', member: {…}, …}
+HomePage.js:45 Data for tune #2221 {format: 'json', id: 2221, name: 'MacArthur Road', url: 'https://thesession.org/tunes/2221', member: {…}, …}
+HomePage.js:45 Data for tune #357 {format: 'json', id: 357, name: "Denis Murphy's", url: 'https://thesession.org/tunes/357', member: {…}, …}
+HomePage.js:45 Data for tune #53 {format: 'json', id: 53, name: "O'Keeffe's", url: 'https://thesession.org/tunes/53', member: {…}, …}
+HomePage.js:45 Data for tune #160 {format: 'json', id: 160, name: "Gallagher's Frolics", url: 'https://thesession.org/tunes/160', member: {…}, …}
+HomePage.js:45 Data for tune #382 {format: 'json', id: 382, name: 'The Battering Ram', url: 'https://thesession.org/tunes/382', member: {…}, …}
+HomePage.js:45 Data for tune #793 {format: 'json', id: 793, name: "Jimmy Ward's", url: 'https://thesession.org/tunes/793', member: {…}, …}
+HomePage.js:45 Data for tune #29 {format: 'json', id: 29, name: 'Dusty Windowsills', url: 'https://thesession.org/tunes/29', member: {…}, …}
+HomePage.js:45 Data for tune #727 {format: 'json', id: 727, name: "Brenda Stubbert's", url: 'https://thesession.org/tunes/727', member: {…}, …}
+HomePage.js:45 Data for tune #511 {format: 'json', id: 511, name: 'The Foxhunters', url: 'https://thesession.org/tunes/511', member: {…}, …}
+HomePage.js:45 Data for tune #33 {format: 'json', id: 33, name: 'Farewell To Ireland', url: 'https://thesession.org/tunes/33', member: {…}, …}
+HomePage.js:45 Data for tune #39 {format: 'json', id: 39, name: 'The Kerry', url: 'https://thesession.org/tunes/39', member: {…}, …}
+HomePage.js:45 Data for tune #482 {format: 'json', id: 482, name: 'The Foxhunter', url: 'https://thesession.org/tunes/482', member: {…}, …}
+HomePage.js:45 Data for tune #307 {format: 'json', id: 307, name: 'Saddle The Pony', url: 'https://thesession.org/tunes/307', member: {…}, …}
+HomePage.js:45 Data for tune #107 {format: 'json', id: 107, name: 'The Atholl Highlanders', url: 'https://thesession.org/tunes/107', member: {…}, …}
+HomePage.js:45 Data for tune #636 {format: 'json', id: 636, name: "The Otter's Holt", url: 'https://thesession.org/tunes/636', member: {…}, …}
+HomePage.js:45 Data for tune #21 {format: 'json', id: 21, name: 'Castle Kelly', url: 'https://thesession.org/tunes/21', member: {…}, …}
+HomePage.js:45 Data for tune #543 {format: 'json', id: 543, name: 'The Ships Are Sailing', url: 'https://thesession.org/tunes/543', member: {…}, …}
+HomePage.js:45 Data for tune #462 {format: 'json', id: 462, name: 'The Dunmore Lasses', url: 'https://thesession.org/tunes/462', member: {…}, …}
+HomePage.js:45 Data for tune #86 {format: 'json', id: 86, name: 'Rakish Paddy', url: 'https://thesession.org/tunes/86', member: {…}, …}
+HomePage.js:45 Data for tune #544 {format: 'json', id: 544, name: "Garrett Barry's", url: 'https://thesession.org/tunes/544', member: {…}, …}
+HomePage.js:45 Data for tune #454 {format: 'json', id: 454, name: 'Tabhair Dom Do Lámh', url: 'https://thesession.org/tunes/454', member: {…}, …}
+HomePage.js:45 Data for tune #35 {format: 'json', id: 35, name: 'The Jig Of Slurs', url: 'https://thesession.org/tunes/35', member: {…}, …}
+HomePage.js:45 Data for tune #222 {format: 'json', id: 222, name: 'The Man Of The House', url: 'https://thesession.org/tunes/222', member: {…}, …}
+HomePage.js:45 Data for tune #381 {format: 'json', id: 381, name: 'I Buried My Wife And Danced On Her Grave', url: 'https://thesession.org/tunes/381', member: {…}, …}
+HomePage.js:45 Data for tune #518 {format: 'json', id: 518, name: "MacLeod's Farewell", url: 'https://thesession.org/tunes/518', member: {…}, …}
+HomePage.js:45 Data for tune #45 {format: 'json', id: 45, name: 'The Humours Of Glendart', url: 'https://thesession.org/tunes/45', member: {…}, …}
+HomePage.js:45 Data for tune #605 {format: 'json', id: 605, name: "Greig's Pipes", url: 'https://thesession.org/tunes/605', member: {…}, …}
+HomePage.js:45 Data for tune #756 {format: 'json', id: 756, name: "Jenny's Chickens", url: 'https://thesession.org/tunes/756', member: {…}, …}
+HomePage.js:45 Data for tune #346 {format: 'json', id: 346, name: 'Music For A Found Harmonium', url: 'https://thesession.org/tunes/346', member: {…}, …}
+HomePage.js:45 Data for tune #601 {format: 'json', id: 601, name: 'The South Wind', url: 'https://thesession.org/tunes/601', member: {…}, …}
+HomePage.js:45 Data for tune #957 {format: 'json', id: 957, name: 'Fanny Power', url: 'https://thesession.org/tunes/957', member: {…}, …}
+HomePage.js:45 Data for tune #219 {format: 'json', id: 219, name: 'The Fermoy Lasses', url: 'https://thesession.org/tunes/219', member: {…}, …}
+HomePage.js:45 Data for tune #210 {format: 'json', id: 210, name: 'The Humours Of Ballyloughlin', url: 'https://thesession.org/tunes/210', member: {…}, …}
+HomePage.js:45 Data for tune #646 {format: 'json', id: 646, name: "Frank's", url: 'https://thesession.org/tunes/646', member: {…}, …}
+HomePage.js:45 Data for tune #562 {format: 'json', id: 562, name: 'Crested Hens', url: 'https://thesession.org/tunes/562', member: {…}, …}
+HomePage.js:45 Data for tune #829 {format: 'json', id: 829, name: 'The Hag At The Churn', url: 'https://thesession.org/tunes/829', member: {…}, …}
+HomePage.js:45 Data for tune #2410 {format: 'json', id: 2410, name: 'Farewell To Whalley Range', url: 'https://thesession.org/tunes/2410', member: {…}, …}
+HomePage.js:45 Data for tune #570 {format: 'json', id: 570, name: "The Sailor's Bonnet", url: 'https://thesession.org/tunes/570', member: {…}, …}
+HomePage.js:45 Data for tune #2549 {format: 'json', id: 2549, name: 'The Flowers Of Edinburgh', url: 'https://thesession.org/tunes/2549', member: {…}, …}
+HomePage.js:45 Data for tune #790 {format: 'json', id: 790, name: 'Planxty Irwin', url: 'https://thesession.org/tunes/790', member: {…}, …}
+HomePage.js:45 Data for tune #791 {format: 'json', id: 791, name: "Father Kelly's", url: 'https://thesession.org/tunes/791', member: {…}, …}
+HomePage.js:45 Data for tune #1292 {format: 'json', id: 1292, name: 'Hector The Hero', url: 'https://thesession.org/tunes/1292', member: {…}, …}
+HomePage.js:45 Data for tune #308 {format: 'json', id: 308, name: "Tobin's Favourite", url: 'https://thesession.org/tunes/308', member: {…}, …}
+HomePage.js:45 Data for tune #139 {format: 'json', id: 139, name: 'The Kerfunten', url: 'https://thesession.org/tunes/139', member: {…}, …}
+HomePage.js:45 Data for tune #4320 {format: 'json', id: 4320, name: 'The Star Of The County Down', url: 'https://thesession.org/tunes/4320', member: {…}, …}
+HomePage.js:45 Data for tune #476 {format: 'json', id: 476, name: "Willie Coleman's", url: 'https://thesession.org/tunes/476', member: {…}, …}
+HomePage.js:45 Data for tune #1499 {format: 'json', id: 1499, name: 'The Old Bush', url: 'https://thesession.org/tunes/1499', member: {…}, …}
+HomePage.js:45 Data for tune #81 {format: 'json', id: 81, name: 'The Pipe On The Hob', url: 'https://thesession.org/tunes/81', member: {…}, …}
+HomePage.js:45 Data for tune #291 {format: 'json', id: 291, name: 'Maggie In The Woods', url: 'https://thesession.org/tunes/291', member: {…}, …}
+HomePage.js:45 Data for tune #879 {format: 'json', id: 879, name: 'An Phis Fhliuch', url: 'https://thesession.org/tunes/879', member: {…}, …}
+HomePage.js:45 Data for tune #891 {format: 'json', id: 891, name: 'The Trip To Durrow', url: 'https://thesession.org/tunes/891', member: {…}, …}
+HomePage.js:45 Data for tune #11 {format: 'json', id: 11, name: 'The Boys Of Malin', url: 'https://thesession.org/tunes/11', member: {…}, …}
+HomePage.js:45 Data for tune #496 {format: 'json', id: 496, name: 'The Glen Of Aherlow', url: 'https://thesession.org/tunes/496', member: {…}, …}
+HomePage.js:45 Data for tune #1977 {format: 'json', id: 1977, name: 'The Reconciliation', url: 'https://thesession.org/tunes/1977', member: {…}, …}
+HomePage.js:45 Data for tune #13 {format: 'json', id: 13, name: "Chief O'Neill's Favourite", url: 'https://thesession.org/tunes/13', member: {…}, …}
+HomePage.js:45 Data for tune #48 {format: 'json', id: 48, name: 'Hardiman The Fiddler', url: 'https://thesession.org/tunes/48', member: {…}, …}
+HomePage.js:45 Data for tune #388 {format: 'json', id: 388, name: 'The Drops Of Brandy', url: 'https://thesession.org/tunes/388', member: {…}, …}
+HomePage.js:45 Data for tune #788 {format: 'json', id: 788, name: "Carolan's Concerto", url: 'https://thesession.org/tunes/788', member: {…}, …}
+HomePage.js:45 Data for tune #471 {format: 'json', id: 471, name: 'Miss Monaghan', url: 'https://thesession.org/tunes/471', member: {…}, …}
+HomePage.js:45 Data for tune #36 {format: 'json', id: 36, name: 'The Golden Keyboard', url: 'https://thesession.org/tunes/36', member: {…}, …}
+HomePage.js:45 Data for tune #477 {format: 'json', id: 477, name: 'The Abbey', url: 'https://thesession.org/tunes/477', member: {…}, …}
+HomePage.js:45 Data for tune #1016 {format: 'json', id: 1016, name: "Josefin's", url: 'https://thesession.org/tunes/1016', member: {…}, …}
+HomePage.js:45 Data for tune #112 {format: 'json', id: 112, name: 'The Trip To Pakistan', url: 'https://thesession.org/tunes/112', member: {…}, …}
+HomePage.js:45 Data for tune #1359 {format: 'json', id: 1359, name: 'Old Hag, You Have Killed Me', url: 'https://thesession.org/tunes/1359', member: {…}, …}
+HomePage.js:45 Data for tune #2516 {format: 'json', id: 2516, name: 'The Foggy Dew', url: 'https://thesession.org/tunes/2516', member: {…}, …}
+HomePage.js:45 Data for tune #129 {format: 'json', id: 129, name: "Dr. Gilbert's", url: 'https://thesession.org/tunes/129', member: {…}, …}
+HomePage.js:45 Data for tune #166 {format: 'json', id: 166, name: 'The Green Mountain', url: 'https://thesession.org/tunes/166', member: {…}, …}
+HomePage.js:45 Data for tune #1398 {format: 'json', id: 1398, name: 'The Star Above The Garter', url: 'https://thesession.org/tunes/1398', member: {…}, …}
+HomePage.js:45 Data for tune #1308 {format: 'json', id: 1308, name: 'After The Battle Of Aughrim', url: 'https://thesession.org/tunes/1308', member: {…}, …}
+HomePage.js:45 Data for tune #733 {format: 'json', id: 733, name: 'The Killarney Boys Of Pleasure', url: 'https://thesession.org/tunes/733', member: {…}, …}
+HomePage.js:45 Data for tune #101 {format: 'json', id: 101, name: 'Smash The Windows', url: 'https://thesession.org/tunes/101', member: {…}, …}
+HomePage.js:45 Data for tune #195 {format: 'json', id: 195, name: 'The Flogging', url: 'https://thesession.org/tunes/195', member: {…}, …}
+HomePage.js:45 Data for tune #478 {format: 'json', id: 478, name: "Cronin's", url: 'https://thesession.org/tunes/478', member: {…}, …}
+HomePage.js:45 Data for tune #423 {format: 'json', id: 423, name: 'The Mouth Of The Tobique', url: 'https://thesession.org/tunes/423', member: {…}, …}
+HomePage.js:45 Data for tune #332 {format: 'json', id: 332, name: 'The White Petticoat', url: 'https://thesession.org/tunes/332', member: {…}, …}
+HomePage.js:45 Data for tune #7 {format: 'json', id: 7, name: 'Bonaparte Crossing The Rhine', url: 'https://thesession.org/tunes/7', member: {…}, …}
+HomePage.js:45 Data for tune #579 {format: 'json', id: 579, name: 'The Bag Of Spuds', url: 'https://thesession.org/tunes/579', member: {…}, …}
+HomePage.js:45 Data for tune #1091 {format: 'json', id: 1091, name: 'The Moving Cloud', url: 'https://thesession.org/tunes/1091', member: {…}, …}
+HomePage.js:45 Data for tune #302 {format: 'json', id: 302, name: 'Maudabawn Chapel', url: 'https://thesession.org/tunes/302', member: {…}, …}
+HomePage.js:45 Data for tune #397 {format: 'json', id: 397, name: 'The Trip To Sligo', url: 'https://thesession.org/tunes/397', member: {…}, …}
+HomePage.js:45 Data for tune #5758 {format: 'json', id: 5758, name: 'The Lochaber Badger', url: 'https://thesession.org/tunes/5758', member: {…}, …}
+HomePage.js:45 Data for tune #351 {format: 'json', id: 351, name: 'The Hag With The Money', url: 'https://thesession.org/tunes/351', member: {…}, …}
+HomePage.js:45 Data for tune #696 {format: 'json', id: 696, name: 'Beare Island', url: 'https://thesession.org/tunes/696', member: {…}, …}
+HomePage.js:45 Data for tune #634 {format: 'json', id: 634, name: 'The Galway Rambler', url: 'https://thesession.org/tunes/634', member: {…}, …}
+HomePage.js:45 Data for tune #4906 {format: 'json', id: 4906, name: 'The Dark Island', url: 'https://thesession.org/tunes/4906', member: {…}, …}
+HomePage.js:45 Data for tune #718 {format: 'json', id: 718, name: "George White's Favourite", url: 'https://thesession.org/tunes/718', member: {…}, …}
+HomePage.js:45 Data for tune #812 {format: 'json', id: 812, name: 'The Virginia', url: 'https://thesession.org/tunes/812', member: {…}, …}
+HomePage.js:45 Data for tune #667 {format: 'json', id: 667, name: 'The Killavil', url: 'https://thesession.org/tunes/667', member: {…}, …}
+HomePage.js:45 Data for tune #358 {format: 'json', id: 358, name: 'Behind The Haystack', url: 'https://thesession.org/tunes/358', member: {…}, …}
+HomePage.js:45 Data for tune #888 {format: 'json', id: 888, name: 'The Mug Of Brown Ale', url: 'https://thesession.org/tunes/888', member: {…}, …}
+HomePage.js:45 Data for tune #261 {format: 'json', id: 261, name: 'The Ships In Full Sail', url: 'https://thesession.org/tunes/261', member: {…}, …}
+HomePage.js:45 Data for tune #467 {format: 'json', id: 467, name: 'The Leitrim Fancy', url: 'https://thesession.org/tunes/467', member: {…}, …}
+HomePage.js:45 Data for tune #17 {format: 'json', id: 17, name: 'The Coleraine', url: 'https://thesession.org/tunes/17', member: {…}, …}
+HomePage.js:45 Data for tune #728 {format: 'json', id: 728, name: 'Scatter The Mud', url: 'https://thesession.org/tunes/728', member: {…}, …}
+HomePage.js:45 Data for tune #1055 {format: 'json', id: 1055, name: "Carolan's Welcome", url: 'https://thesession.org/tunes/1055', member: {…}, …}
+HomePage.js:45 Data for tune #424 {format: 'json', id: 424, name: 'The Fairy Dance', url: 'https://thesession.org/tunes/424', member: {…}, …}
+HomePage.js:45 Data for tune #481 {format: 'json', id: 481, name: "Bill Sullivan's", url: 'https://thesession.org/tunes/481', member: {…}, …}
+HomePage.js:45 Data for tune #192 {format: 'json', id: 192, name: "Jenny Nettle's Fancy", url: 'https://thesession.org/tunes/192', member: {…}, …}
+HomePage.js:45 Data for tune #1080 {format: 'json', id: 1080, name: "Father O'Flynn", url: 'https://thesession.org/tunes/1080', member: {…}, …}
+HomePage.js:45 Data for tune #93 {format: 'json', id: 93, name: 'The Cock And The Hen', url: 'https://thesession.org/tunes/93', member: {…}, …}
+HomePage.js:45 Data for tune #1356 {format: 'json', id: 1356, name: "Soldier's Joy", url: 'https://thesession.org/tunes/1356', member: {…}, …}
+HomePage.js:45 Data for tune #1552 {format: 'json', id: 1552, name: 'Lucy Campbell', url: 'https://thesession.org/tunes/1552', member: {…}, …}
+HomePage.js:45 Data for tune #408 {format: 'json', id: 408, name: "Dick Gossip's", url: 'https://thesession.org/tunes/408', member: {…}, …}
+HomePage.js:45 Data for tune #58 {format: 'json', id: 58, name: 'The Lads Of Laois', url: 'https://thesession.org/tunes/58', member: {…}, …}
+HomePage.js:45 Data for tune #273 {format: 'json', id: 273, name: 'The Castle', url: 'https://thesession.org/tunes/273', member: {…}, …}
+HomePage.js:199 ---- InfiniteScroll requesting page #12 ----
+HomePage.js:122 A1. API call: https://thesession.org/tunes/search?type=&mode=&q=&perpage=20&page=12&format=json
+HomePage.js:73 checkResults() called
+HomePage.js:105 Not performing check - no key filter, or threshold not exceeded
+HomePage.js:31 dealWithResults() called
+HomePage.js:40 Getting data for tune # 612
+HomePage.js:40 Getting data for tune # 808
+HomePage.js:40 Getting data for tune # 228
+HomePage.js:40 Getting data for tune # 63
+HomePage.js:40 Getting data for tune # 239
+HomePage.js:40 Getting data for tune # 472
+HomePage.js:40 Getting data for tune # 1441
+HomePage.js:40 Getting data for tune # 901
+HomePage.js:40 Getting data for tune # 320
+HomePage.js:40 Getting data for tune # 61
+HomePage.js:40 Getting data for tune # 259
+HomePage.js:40 Getting data for tune # 206
+HomePage.js:40 Getting data for tune # 322
+HomePage.js:40 Getting data for tune # 38
+HomePage.js:40 Getting data for tune # 637
+HomePage.js:40 Getting data for tune # 94
+HomePage.js:40 Getting data for tune # 500
+HomePage.js:40 Getting data for tune # 706
+HomePage.js:40 Getting data for tune # 563
+HomePage.js:40 Getting data for tune # 887
+HomePage.js:45 Data for tune #612 {format: 'json', id: 612, name: 'Na Ceannabháin Bhána', url: 'https://thesession.org/tunes/612', member: {…}, …}
+HomePage.js:45 Data for tune #808 {format: 'json', id: 808, name: 'The Cook In The Kitchen', url: 'https://thesession.org/tunes/808', member: {…}, …}
+HomePage.js:45 Data for tune #63 {format: 'json', id: 63, name: "Last Night's Fun", url: 'https://thesession.org/tunes/63', member: {…}, …}
+HomePage.js:45 Data for tune #901 {format: 'json', id: 901, name: 'Speed The Plough', url: 'https://thesession.org/tunes/901', member: {…}, …}
+HomePage.js:45 Data for tune #1441 {format: 'json', id: 1441, name: 'The Dawning Of The Day', url: 'https://thesession.org/tunes/1441', member: {…}, …}
+HomePage.js:45 Data for tune #228 {format: 'json', id: 228, name: 'The Humours Of Ennistymon', url: 'https://thesession.org/tunes/228', member: {…}, …}
+HomePage.js:45 Data for tune #472 {format: 'json', id: 472, name: "The Hunter's House", url: 'https://thesession.org/tunes/472', member: {…}, …}
+HomePage.js:45 Data for tune #239 {format: 'json', id: 239, name: 'The Ballydesmond', url: 'https://thesession.org/tunes/239', member: {…}, …}
+HomePage.js:45 Data for tune #320 {format: 'json', id: 320, name: 'The Bank Of Ireland', url: 'https://thesession.org/tunes/320', member: {…}, …}
+HomePage.js:45 Data for tune #61 {format: 'json', id: 61, name: "Langstrom's Pony", url: 'https://thesession.org/tunes/61', member: {…}, …}
+HomePage.js:45 Data for tune #259 {format: 'json', id: 259, name: "The Devil's Dream", url: 'https://thesession.org/tunes/259', member: {…}, …}
+HomePage.js:45 Data for tune #206 {format: 'json', id: 206, name: 'The Mooncoin', url: 'https://thesession.org/tunes/206', member: {…}, …}
+HomePage.js:45 Data for tune #38 {format: 'json', id: 38, name: 'The Galway', url: 'https://thesession.org/tunes/38', member: {…}, …}
+HomePage.js:45 Data for tune #322 {format: 'json', id: 322, name: 'The Green Fields Of Rossbeigh', url: 'https://thesession.org/tunes/322', member: {…}, …}
+HomePage.js:45 Data for tune #637 {format: 'json', id: 637, name: 'The Roscommon', url: 'https://thesession.org/tunes/637', member: {…}, …}
+HomePage.js:45 Data for tune #94 {format: 'json', id: 94, name: 'The Scholar', url: 'https://thesession.org/tunes/94', member: {…}, …}
+HomePage.js:45 Data for tune #500 {format: 'json', id: 500, name: 'Rolling In The Barrel', url: 'https://thesession.org/tunes/500', member: {…}, …}
+HomePage.js:45 Data for tune #706 {format: 'json', id: 706, name: "Mairi's Wedding", url: 'https://thesession.org/tunes/706', member: {…}, …}
+HomePage.js:45 Data for tune #563 {format: 'json', id: 563, name: 'The Longford Collector', url: 'https://thesession.org/tunes/563', member: {…}, …}
+HomePage.js:45 Data for tune #887 {format: 'json', id: 887, name: 'The New Copperplate', url: 'https://thesession.org/tunes/887', member: {…}, …}
+HomePage.js:199 ---- InfiniteScroll requesting page #13 ----
+HomePage.js:122 A1. API call: https://thesession.org/tunes/search?type=&mode=&q=&perpage=20&page=13&format=json
+HomePage.js:73 checkResults() called
+HomePage.js:105 Not performing check - no key filter, or threshold not exceeded
+HomePage.js:31 dealWithResults() called
+HomePage.js:40 Getting data for tune # 872
+HomePage.js:40 Getting data for tune # 556
+HomePage.js:40 Getting data for tune # 771
+HomePage.js:40 Getting data for tune # 452
+HomePage.js:40 Getting data for tune # 1638
+HomePage.js:40 Getting data for tune # 1316
+HomePage.js:40 Getting data for tune # 2204
+HomePage.js:40 Getting data for tune # 980
+HomePage.js:40 Getting data for tune # 159
+HomePage.js:40 Getting data for tune # 142
+HomePage.js:40 Getting data for tune # 281
+HomePage.js:40 Getting data for tune # 41
+HomePage.js:40 Getting data for tune # 46
+HomePage.js:40 Getting data for tune # 16
+HomePage.js:40 Getting data for tune # 23
+HomePage.js:40 Getting data for tune # 638
+HomePage.js:40 Getting data for tune # 4
+HomePage.js:40 Getting data for tune # 513
+HomePage.js:40 Getting data for tune # 1447
+HomePage.js:40 Getting data for tune # 150
+HomePage.js:45 Data for tune #872 {format: 'json', id: 872, name: "Fisher's", url: 'https://thesession.org/tunes/872', member: {…}, …}
+HomePage.js:45 Data for tune #2204 {format: 'json', id: 2204, name: "O'Sullivan's March", url: 'https://thesession.org/tunes/2204', member: {…}, …}
+HomePage.js:45 Data for tune #771 {format: 'json', id: 771, name: 'The Carraroe', url: 'https://thesession.org/tunes/771', member: {…}, …}
+HomePage.js:45 Data for tune #452 {format: 'json', id: 452, name: "Fred Finn's", url: 'https://thesession.org/tunes/452', member: {…}, …}
+HomePage.js:45 Data for tune #556 {format: 'json', id: 556, name: "Sweeney's Buttermilk", url: 'https://thesession.org/tunes/556', member: {…}, …}
+HomePage.js:45 Data for tune #1316 {format: 'json', id: 1316, name: "Maggie's Pancakes", url: 'https://thesession.org/tunes/1316', member: {…}, …}
+HomePage.js:45 Data for tune #1638 {format: 'json', id: 1638, name: 'Tatter Jack Walsh', url: 'https://thesession.org/tunes/1638', member: {…}, …}
+HomePage.js:45 Data for tune #980 {format: 'json', id: 980, name: 'The Humours Of Tullycrine', url: 'https://thesession.org/tunes/980', member: {…}, …}
+HomePage.js:45 Data for tune #159 {format: 'json', id: 159, name: "Denis Murphy's", url: 'https://thesession.org/tunes/159', member: {…}, …}
+HomePage.js:45 Data for tune #142 {format: 'json', id: 142, name: 'The Boyne Hunt', url: 'https://thesession.org/tunes/142', member: {…}, …}
+HomePage.js:45 Data for tune #281 {format: 'json', id: 281, name: "Master Crowley's", url: 'https://thesession.org/tunes/281', member: {…}, …}
+HomePage.js:45 Data for tune #41 {format: 'json', id: 41, name: 'The Green Groves Of Erin', url: 'https://thesession.org/tunes/41', member: {…}, …}
+HomePage.js:45 Data for tune #46 {format: 'json', id: 46, name: 'The Humours Of Whiskey', url: 'https://thesession.org/tunes/46', member: {…}, …}
+HomePage.js:45 Data for tune #16 {format: 'json', id: 16, name: 'The Clumsy Lover', url: 'https://thesession.org/tunes/16', member: {…}, …}
+HomePage.js:45 Data for tune #23 {format: 'json', id: 23, name: 'The Dingle Regatta', url: 'https://thesession.org/tunes/23', member: {…}, …}
+HomePage.js:45 Data for tune #638 {format: 'json', id: 638, name: 'Lord Mayo', url: 'https://thesession.org/tunes/638', member: {…}, …}
+HomePage.js:45 Data for tune #4 {format: 'json', id: 4, name: 'The Belfast', url: 'https://thesession.org/tunes/4', member: {…}, …}
+HomePage.js:45 Data for tune #513 {format: 'json', id: 513, name: 'Good Morning To Your Nightcap', url: 'https://thesession.org/tunes/513', member: {…}, …}
+HomePage.js:45 Data for tune #1447 {format: 'json', id: 1447, name: "Whelan's", url: 'https://thesession.org/tunes/1447', member: {…}, …}
+HomePage.js:45 Data for tune #150 {format: 'json', id: 150, name: "Paddy Fahey's", url: 'https://thesession.org/tunes/150', member: {…}, …}
+HomePage.js:199 ---- InfiniteScroll requesting page #14 ----
+HomePage.js:122 A1. API call: https://thesession.org/tunes/search?type=&mode=&q=&perpage=20&page=14&format=json
+HomePage.js:73 checkResults() called
+HomePage.js:105 Not performing check - no key filter, or threshold not exceeded
+HomePage.js:31 dealWithResults() called
+HomePage.js:40 Getting data for tune # 1098
+HomePage.js:40 Getting data for tune # 264
+HomePage.js:40 Getting data for tune # 324
+HomePage.js:40 Getting data for tune # 635
+HomePage.js:40 Getting data for tune # 1164
+HomePage.js:40 Getting data for tune # 384
+HomePage.js:40 Getting data for tune # 303
+HomePage.js:40 Getting data for tune # 343
+HomePage.js:40 Getting data for tune # 359
+HomePage.js:40 Getting data for tune # 50
+HomePage.js:40 Getting data for tune # 869
+HomePage.js:40 Getting data for tune # 37
+HomePage.js:40 Getting data for tune # 474
+HomePage.js:40 Getting data for tune # 575
+HomePage.js:40 Getting data for tune # 528
+HomePage.js:40 Getting data for tune # 401
+HomePage.js:40 Getting data for tune # 234
+HomePage.js:40 Getting data for tune # 1423
+HomePage.js:40 Getting data for tune # 1118
+HomePage.js:40 Getting data for tune # 2881
+HomePage.js:45 Data for tune #635 {format: 'json', id: 635, name: 'Give Us A Drink Of Water', url: 'https://thesession.org/tunes/635', member: {…}, …}
+HomePage.js:45 Data for tune #1164 {format: 'json', id: 1164, name: 'Far From Home', url: 'https://thesession.org/tunes/1164', member: {…}, …}
+HomePage.js:45 Data for tune #384 {format: 'json', id: 384, name: 'The Dublin', url: 'https://thesession.org/tunes/384', member: {…}, …}
+HomePage.js:45 Data for tune #264 {format: 'json', id: 264, name: "Lanigan's Ball", url: 'https://thesession.org/tunes/264', member: {…}, …}
+HomePage.js:45 Data for tune #324 {format: 'json', id: 324, name: "Stan Chapman's", url: 'https://thesession.org/tunes/324', member: {…}, …}
+HomePage.js:45 Data for tune #1098 {format: 'json', id: 1098, name: 'The Haunted House', url: 'https://thesession.org/tunes/1098', member: {…}, …}
+HomePage.js:45 Data for tune #303 {format: 'json', id: 303, name: 'Music In The Glen', url: 'https://thesession.org/tunes/303', member: {…}, …}
+HomePage.js:45 Data for tune #343 {format: 'json', id: 343, name: 'The Boys Of The Lough', url: 'https://thesession.org/tunes/343', member: {…}, …}
+HomePage.js:45 Data for tune #359 {format: 'json', id: 359, name: "Martin Wynne's", url: 'https://thesession.org/tunes/359', member: {…}, …}
+HomePage.js:45 Data for tune #50 {format: 'json', id: 50, name: "Jackie Coleman's", url: 'https://thesession.org/tunes/50', member: {…}, …}
+HomePage.js:45 Data for tune #37 {format: 'json', id: 37, name: 'The Gold Ring', url: 'https://thesession.org/tunes/37', member: {…}, …}
+HomePage.js:45 Data for tune #869 {format: 'json', id: 869, name: "Kitty's Wedding", url: 'https://thesession.org/tunes/869', member: {…}, …}
+HomePage.js:45 Data for tune #474 {format: 'json', id: 474, name: 'Come West Along The Road', url: 'https://thesession.org/tunes/474', member: {…}, …}
+HomePage.js:45 Data for tune #575 {format: 'json', id: 575, name: 'The Reel Of Rio', url: 'https://thesession.org/tunes/575', member: {…}, …}
+HomePage.js:45 Data for tune #528 {format: 'json', id: 528, name: "Tuttle's", url: 'https://thesession.org/tunes/528', member: {…}, …}
+HomePage.js:45 Data for tune #401 {format: 'json', id: 401, name: 'The Gander In The Pratie Hole', url: 'https://thesession.org/tunes/401', member: {…}, …}
+HomePage.js:45 Data for tune #234 {format: 'json', id: 234, name: "Farrel O'Gara's", url: 'https://thesession.org/tunes/234', member: {…}, …}
+HomePage.js:45 Data for tune #1423 {format: 'json', id: 1423, name: 'The Broken Pledge', url: 'https://thesession.org/tunes/1423', member: {…}, …}
+HomePage.js:45 Data for tune #2881 {format: 'json', id: 2881, name: "Devanny's Goat", url: 'https://thesession.org/tunes/2881', member: {…}, …}
+HomePage.js:45 Data for tune #1118 {format: 'json', id: 1118, name: 'The High Road To Linton', url: 'https://thesession.org/tunes/1118', member: {…}, …}
+HomePage.js:199 ---- InfiniteScroll requesting page #15 ----
+HomePage.js:122 A1. API call: https://thesession.org/tunes/search?type=&mode=&q=&perpage=20&page=15&format=json
+HomePage.js:73 checkResults() called
+HomePage.js:105 Not performing check - no key filter, or threshold not exceeded
+HomePage.js:31 dealWithResults() called
+HomePage.js:40 Getting data for tune # 59
+HomePage.js:40 Getting data for tune # 79
+HomePage.js:40 Getting data for tune # 953
+HomePage.js:40 Getting data for tune # 880
+HomePage.js:40 Getting data for tune # 1148
+HomePage.js:40 Getting data for tune # 283
+HomePage.js:40 Getting data for tune # 1863
+HomePage.js:40 Getting data for tune # 200
+HomePage.js:40 Getting data for tune # 1892
+HomePage.js:40 Getting data for tune # 986
+HomePage.js:40 Getting data for tune # 174
+HomePage.js:40 Getting data for tune # 370
+HomePage.js:40 Getting data for tune # 741
+HomePage.js:40 Getting data for tune # 227
+HomePage.js:40 Getting data for tune # 2589
+HomePage.js:40 Getting data for tune # 1566
+HomePage.js:40 Getting data for tune # 5020
+HomePage.js:40 Getting data for tune # 652
+HomePage.js:40 Getting data for tune # 380
+HomePage.js:40 Getting data for tune # 232
+HomePage.js:45 Data for tune #59 {format: 'json', id: 59, name: 'Lady Anne Montgomery', url: 'https://thesession.org/tunes/59', member: {…}, …}
+HomePage.js:199 ---- InfiniteScroll requesting page #16 ----
+HomePage.js:45 Data for tune #1148 {format: 'json', id: 1148, name: 'Drag Her Round The Road', url: 'https://thesession.org/tunes/1148', member: {…}, …}
+HomePage.js:45 Data for tune #283 {format: 'json', id: 283, name: "The Hunter's Purse", url: 'https://thesession.org/tunes/283', member: {…}, …}
+HomePage.js:45 Data for tune #880 {format: 'json', id: 880, name: 'Da New Rigged Ship', url: 'https://thesession.org/tunes/880', member: {…}, …}
+HomePage.js:122 A1. API call: https://thesession.org/tunes/search?type=&mode=&q=&perpage=20&page=16&format=json
+HomePage.js:45 Data for tune #953 {format: 'json', id: 953, name: "Elizabeth Kelly's Delight", url: 'https://thesession.org/tunes/953', member: {…}, …}
+HomePage.js:199 ---- InfiniteScroll requesting page #17 ----
+HomePage.js:122 A1. API call: https://thesession.org/tunes/search?type=&mode=&q=&perpage=20&page=17&format=json
+HomePage.js:45 Data for tune #79 {format: 'json', id: 79, name: "Paddy Ryan's Dream", url: 'https://thesession.org/tunes/79', member: {…}, …}
+HomePage.js:199 ---- InfiniteScroll requesting page #18 ----
+HomePage.js:45 Data for tune #1863 {format: 'json', id: 1863, name: 'Da Slockit Light', url: 'https://thesession.org/tunes/1863', member: {…}, …}
+HomePage.js:122 A1. API call: https://thesession.org/tunes/search?type=&mode=&q=&perpage=20&page=18&format=json
+HomePage.js:199 ---- InfiniteScroll requesting page #19 ----
+HomePage.js:45 Data for tune #200 {format: 'json', id: 200, name: 'Splendid Isolation', url: 'https://thesession.org/tunes/200', member: {…}, …}
+HomePage.js:45 Data for tune #1892 {format: 'json', id: 1892, name: "Niel Gow's Lament For His Second Wife", url: 'https://thesession.org/tunes/1892', member: {…}, …}
+HomePage.js:45 Data for tune #174 {format: 'json', id: 174, name: 'The Curlews', url: 'https://thesession.org/tunes/174', member: {…}, …}
+HomePage.js:45 Data for tune #986 {format: 'json', id: 986, name: 'The Arran Boat Song', url: 'https://thesession.org/tunes/986', member: {…}, …}
+HomePage.js:122 A1. API call: https://thesession.org/tunes/search?type=&mode=&q=&perpage=20&page=19&format=json
+HomePage.js:199 ---- InfiniteScroll requesting page #20 ----
+HomePage.js:45 Data for tune #370 {format: 'json', id: 370, name: "Jenny's Welcome To Charlie", url: 'https://thesession.org/tunes/370', member: {…}, …}
+HomePage.js:122 A1. API call: https://thesession.org/tunes/search?type=&mode=&q=&perpage=20&page=20&format=json
+HomePage.js:45 Data for tune #741 {format: 'json', id: 741, name: "Paddy O'Rafferty", url: 'https://thesession.org/tunes/741', member: {…}, …}
+HomePage.js:199 ---- InfiniteScroll requesting page #21 ----
+HomePage.js:122 A1. API call: https://thesession.org/tunes/search?type=&mode=&q=&perpage=20&page=21&format=json
+HomePage.js:45 Data for tune #227 {format: 'json', id: 227, name: 'The Crooked Road', url: 'https://thesession.org/tunes/227', member: {…}, …}
+HomePage.js:45 Data for tune #2589 {format: 'json', id: 2589, name: 'Pressed For Time', url: 'https://thesession.org/tunes/2589', member: {…}, …}
+HomePage.js:199 ---- InfiniteScroll requesting page #22 ----
+HomePage.js:45 Data for tune #1566 {format: 'json', id: 1566, name: 'The Holly Bush', url: 'https://thesession.org/tunes/1566', member: {…}, …}
+HomePage.js:45 Data for tune #5020 {format: 'json', id: 5020, name: 'Midnight On The Water', url: 'https://thesession.org/tunes/5020', member: {…}, …}
+HomePage.js:122 A1. API call: https://thesession.org/tunes/search?type=&mode=&q=&perpage=20&page=22&format=json
+HomePage.js:45 Data for tune #652 {format: 'json', id: 652, name: 'The Plains Of Boyle', url: 'https://thesession.org/tunes/652', member: {…}, …}
+HomePage.js:199 ---- InfiniteScroll requesting page #23 ----
+HomePage.js:45 Data for tune #380 {format: 'json', id: 380, name: 'Jenny Dang The Weaver', url: 'https://thesession.org/tunes/380', member: {…}, …}
+HomePage.js:45 Data for tune #232 {format: 'json', id: 232, name: 'The Walls Of Liscarrol', url: 'https://thesession.org/tunes/232', member: {…}, …}
+HomePage.js:122 A1. API call: https://thesession.org/tunes/search?type=&mode=&q=&perpage=20&page=23&format=json
+HomePage.js:199 ---- InfiniteScroll requesting page #24 ----
+HomePage.js:122 A1. API call: https://thesession.org/tunes/search?type=&mode=&q=&perpage=20&page=24&format=json
+HomePage.js:73 checkResults() called
+HomePage.js:105 Not performing check - no key filter, or threshold not exceeded
+HomePage.js:31 dealWithResults() called
+HomePage.js:40 Getting data for tune # 1754
+HomePage.js:40 Getting data for tune # 177
+HomePage.js:40 Getting data for tune # 389
+HomePage.js:40 Getting data for tune # 1615
+HomePage.js:40 Getting data for tune # 1343
+HomePage.js:40 Getting data for tune # 827
+HomePage.js:40 Getting data for tune # 1100
+HomePage.js:40 Getting data for tune # 319
+HomePage.js:40 Getting data for tune # 161
+HomePage.js:40 Getting data for tune # 418
+HomePage.js:40 Getting data for tune # 1285
+HomePage.js:40 Getting data for tune # 535
+HomePage.js:40 Getting data for tune # 229
+HomePage.js:40 Getting data for tune # 1497
+HomePage.js:40 Getting data for tune # 54
+HomePage.js:40 Getting data for tune # 217
+HomePage.js:40 Getting data for tune # 350
+HomePage.js:40 Getting data for tune # 2575
+HomePage.js:40 Getting data for tune # 1468
+HomePage.js:40 Getting data for tune # 736
+HomePage.js:73 checkResults() called
+HomePage.js:105 Not performing check - no key filter, or threshold not exceeded
+HomePage.js:31 dealWithResults() called
+HomePage.js:40 Getting data for tune # 263
+HomePage.js:40 Getting data for tune # 1077
+HomePage.js:40 Getting data for tune # 514
+HomePage.js:40 Getting data for tune # 4428
+HomePage.js:40 Getting data for tune # 1716
+HomePage.js:40 Getting data for tune # 2434
+HomePage.js:40 Getting data for tune # 187
+HomePage.js:40 Getting data for tune # 789
+HomePage.js:40 Getting data for tune # 948
+HomePage.js:40 Getting data for tune # 82
+HomePage.js:40 Getting data for tune # 125
+HomePage.js:40 Getting data for tune # 820
+HomePage.js:40 Getting data for tune # 719
+HomePage.js:40 Getting data for tune # 1678
+HomePage.js:40 Getting data for tune # 2639
+HomePage.js:40 Getting data for tune # 1301
+HomePage.js:40 Getting data for tune # 767
+HomePage.js:40 Getting data for tune # 1365
+HomePage.js:40 Getting data for tune # 376
+HomePage.js:40 Getting data for tune # 398
+HomePage.js:73 checkResults() called
+HomePage.js:105 Not performing check - no key filter, or threshold not exceeded
+HomePage.js:31 dealWithResults() called
+HomePage.js:40 Getting data for tune # 1263
+HomePage.js:40 Getting data for tune # 537
+HomePage.js:40 Getting data for tune # 1070
+HomePage.js:40 Getting data for tune # 4403
+HomePage.js:40 Getting data for tune # 5476
+HomePage.js:40 Getting data for tune # 1133
+HomePage.js:40 Getting data for tune # 843
+HomePage.js:40 Getting data for tune # 1104
+HomePage.js:40 Getting data for tune # 754
+HomePage.js:40 Getting data for tune # 347
+HomePage.js:40 Getting data for tune # 1421
+HomePage.js:40 Getting data for tune # 3690
+HomePage.js:40 Getting data for tune # 883
+HomePage.js:40 Getting data for tune # 333
+HomePage.js:40 Getting data for tune # 483
+HomePage.js:40 Getting data for tune # 463
+HomePage.js:40 Getting data for tune # 711
+HomePage.js:40 Getting data for tune # 870
+HomePage.js:40 Getting data for tune # 840
+HomePage.js:40 Getting data for tune # 1754
+HomePage.js:73 checkResults() called
+HomePage.js:105 Not performing check - no key filter, or threshold not exceeded
+HomePage.js:31 dealWithResults() called
+HomePage.js:40 Getting data for tune # 2259
+HomePage.js:40 Getting data for tune # 185
+HomePage.js:40 Getting data for tune # 632
+HomePage.js:40 Getting data for tune # 724
+HomePage.js:40 Getting data for tune # 6655
+HomePage.js:40 Getting data for tune # 6195
+HomePage.js:40 Getting data for tune # 1026
+HomePage.js:40 Getting data for tune # 615
+HomePage.js:40 Getting data for tune # 1554
+HomePage.js:40 Getting data for tune # 885
+HomePage.js:40 Getting data for tune # 729
+HomePage.js:40 Getting data for tune # 6867
+HomePage.js:40 Getting data for tune # 90
+HomePage.js:40 Getting data for tune # 1049
+HomePage.js:40 Getting data for tune # 2224
+HomePage.js:40 Getting data for tune # 292
+HomePage.js:40 Getting data for tune # 385
+HomePage.js:40 Getting data for tune # 207
+HomePage.js:40 Getting data for tune # 594
+HomePage.js:40 Getting data for tune # 999
+HomePage.js:73 checkResults() called
+HomePage.js:105 Not performing check - no key filter, or threshold not exceeded
+HomePage.js:31 dealWithResults() called
+HomePage.js:40 Getting data for tune # 442
+HomePage.js:40 Getting data for tune # 553
+HomePage.js:40 Getting data for tune # 9942
+HomePage.js:40 Getting data for tune # 649
+HomePage.js:40 Getting data for tune # 487
+HomePage.js:40 Getting data for tune # 531
+HomePage.js:40 Getting data for tune # 1307
+HomePage.js:40 Getting data for tune # 737
+HomePage.js:40 Getting data for tune # 921
+HomePage.js:40 Getting data for tune # 1209
+HomePage.js:40 Getting data for tune # 196
+HomePage.js:40 Getting data for tune # 406
+HomePage.js:40 Getting data for tune # 327
+HomePage.js:40 Getting data for tune # 769
+HomePage.js:40 Getting data for tune # 2540
+HomePage.js:40 Getting data for tune # 816
+HomePage.js:40 Getting data for tune # 1272
+HomePage.js:40 Getting data for tune # 583
+HomePage.js:40 Getting data for tune # 835
+HomePage.js:40 Getting data for tune # 284
+HomePage.js:73 checkResults() called
+HomePage.js:105 Not performing check - no key filter, or threshold not exceeded
+HomePage.js:31 dealWithResults() called
+HomePage.js:40 Getting data for tune # 3016
+HomePage.js:40 Getting data for tune # 40
+HomePage.js:40 Getting data for tune # 1578
+HomePage.js:40 Getting data for tune # 976
+HomePage.js:40 Getting data for tune # 143
+HomePage.js:40 Getting data for tune # 705
+HomePage.js:40 Getting data for tune # 8085
+HomePage.js:40 Getting data for tune # 391
+HomePage.js:40 Getting data for tune # 148
+HomePage.js:40 Getting data for tune # 1500
+HomePage.js:40 Getting data for tune # 367
+HomePage.js:40 Getting data for tune # 695
+HomePage.js:40 Getting data for tune # 1807
+HomePage.js:40 Getting data for tune # 325
+HomePage.js:40 Getting data for tune # 1340
+HomePage.js:40 Getting data for tune # 2266
+HomePage.js:40 Getting data for tune # 1621
+HomePage.js:40 Getting data for tune # 280
+HomePage.js:40 Getting data for tune # 1097
+HomePage.js:40 Getting data for tune # 414
+HomePage.js:45 Data for tune #1754 {format: 'json', id: 1754, name: 'The Jolly Tinker', url: 'https://thesession.org/tunes/1754', member: {…}, …}
+HomePage.js:45 Data for tune #177 {format: 'json', id: 177, name: 'Seán Sa Cheo', url: 'https://thesession.org/tunes/177', member: {…}, …}
+HomePage.js:45 Data for tune #389 {format: 'json', id: 389, name: 'The Eavesdropper', url: 'https://thesession.org/tunes/389', member: {…}, …}
+HomePage.js:45 Data for tune #827 {format: 'json', id: 827, name: 'The Templehouse', url: 'https://thesession.org/tunes/827', member: {…}, …}
+HomePage.js:45 Data for tune #1343 {format: 'json', id: 1343, name: "The Peeler's Jacket", url: 'https://thesession.org/tunes/1343', member: {…}, …}
+HomePage.js:45 Data for tune #1615 {format: 'json', id: 1615, name: 'The Road To Glountane', url: 'https://thesession.org/tunes/1615', member: {…}, …}
+HomePage.js:45 Data for tune #1100 {format: 'json', id: 1100, name: "Tommy Peoples'", url: 'https://thesession.org/tunes/1100', member: {…}, …}
+HomePage.js:45 Data for tune #319 {format: 'json', id: 319, name: "Jerry's Beaver Hat", url: 'https://thesession.org/tunes/319', member: {…}, …}
+HomePage.js:73 checkResults() called
+HomePage.js:105 Not performing check - no key filter, or threshold not exceeded
+HomePage.js:31 dealWithResults() called
+HomePage.js:40 Getting data for tune # 864
+HomePage.js:40 Getting data for tune # 690
+HomePage.js:40 Getting data for tune # 841
+HomePage.js:40 Getting data for tune # 66
+HomePage.js:40 Getting data for tune # 378
+HomePage.js:40 Getting data for tune # 165
+HomePage.js:40 Getting data for tune # 1462
+HomePage.js:40 Getting data for tune # 663
+HomePage.js:40 Getting data for tune # 532
+HomePage.js:40 Getting data for tune # 1030
+HomePage.js:40 Getting data for tune # 1020
+HomePage.js:40 Getting data for tune # 3842
+HomePage.js:40 Getting data for tune # 1831
+HomePage.js:40 Getting data for tune # 457
+HomePage.js:40 Getting data for tune # 7425
+HomePage.js:40 Getting data for tune # 851
+HomePage.js:40 Getting data for tune # 3140
+HomePage.js:40 Getting data for tune # 787
+HomePage.js:40 Getting data for tune # 132
+HomePage.js:40 Getting data for tune # 1002
+HomePage.js:73 checkResults() called
+HomePage.js:105 Not performing check - no key filter, or threshold not exceeded
+HomePage.js:31 dealWithResults() called
+HomePage.js:40 Getting data for tune # 1446
+HomePage.js:40 Getting data for tune # 223
+HomePage.js:40 Getting data for tune # 661
+HomePage.js:40 Getting data for tune # 390
+HomePage.js:40 Getting data for tune # 878
+HomePage.js:40 Getting data for tune # 761
+HomePage.js:40 Getting data for tune # 429
+HomePage.js:40 Getting data for tune # 455
+HomePage.js:40 Getting data for tune # 4735
+HomePage.js:40 Getting data for tune # 1035
+HomePage.js:40 Getting data for tune # 411
+HomePage.js:40 Getting data for tune # 235
+HomePage.js:40 Getting data for tune # 2254
+HomePage.js:40 Getting data for tune # 3110
+HomePage.js:40 Getting data for tune # 974
+HomePage.js:40 Getting data for tune # 1581
+HomePage.js:40 Getting data for tune # 1746
+HomePage.js:40 Getting data for tune # 417
+HomePage.js:40 Getting data for tune # 2025
+HomePage.js:40 Getting data for tune # 1385
+HomePage.js:45 Data for tune #418 {format: 'json', id: 418, name: 'Ievan Polkka', url: 'https://thesession.org/tunes/418', member: {…}, …}
+HomePage.js:45 Data for tune #161 {format: 'json', id: 161, name: 'Tell Her I Am', url: 'https://thesession.org/tunes/161', member: {…}, …}
+HomePage.js:73 checkResults() called
+HomePage.js:105 Not performing check - no key filter, or threshold not exceeded
+HomePage.js:31 dealWithResults() called
+HomePage.js:40 Getting data for tune # 1303
+HomePage.js:40 Getting data for tune # 1347
+HomePage.js:40 Getting data for tune # 96
+HomePage.js:40 Getting data for tune # 991
+HomePage.js:40 Getting data for tune # 590
+HomePage.js:40 Getting data for tune # 671
+HomePage.js:40 Getting data for tune # 1637
+HomePage.js:40 Getting data for tune # 6
+HomePage.js:40 Getting data for tune # 1414
+HomePage.js:40 Getting data for tune # 1142
+HomePage.js:40 Getting data for tune # 2067
+HomePage.js:40 Getting data for tune # 938
+HomePage.js:40 Getting data for tune # 444
+HomePage.js:40 Getting data for tune # 2154
+HomePage.js:40 Getting data for tune # 2170
+HomePage.js:40 Getting data for tune # 369
+HomePage.js:40 Getting data for tune # 866
+HomePage.js:40 Getting data for tune # 1314
+HomePage.js:40 Getting data for tune # 131
+HomePage.js:40 Getting data for tune # 255
+HomePage.js:45 Data for tune #1285 {format: 'json', id: 1285, name: 'Staten Island', url: 'https://thesession.org/tunes/1285', member: {…}, …}
+HomePage.js:45 Data for tune #1497 {format: 'json', id: 1497, name: 'The Donegal Lass', url: 'https://thesession.org/tunes/1497', member: {…}, …}
+HomePage.js:45 Data for tune #54 {format: 'json', id: 54, name: 'King Of The Pipers', url: 'https://thesession.org/tunes/54', member: {…}, …}
+HomePage.js:45 Data for tune #535 {format: 'json', id: 535, name: 'The Boys Of Ballisodare', url: 'https://thesession.org/tunes/535', member: {…}, …}
+HomePage.js:45 Data for tune #350 {format: 'json', id: 350, name: 'The Torn Jacket', url: 'https://thesession.org/tunes/350', member: {…}, …}
+HomePage.js:45 Data for tune #229 {format: 'json', id: 229, name: "Dowd's Favourite", url: 'https://thesession.org/tunes/229', member: {…}, …}
+HomePage.js:45 Data for tune #217 {format: 'json', id: 217, name: 'The Orphan', url: 'https://thesession.org/tunes/217', member: {…}, …}
+HomePage.js:45 Data for tune #2575 {format: 'json', id: 2575, name: 'Eleanor Plunkett', url: 'https://thesession.org/tunes/2575', member: {…}, …}
+HomePage.js:45 Data for tune #1468 {format: 'json', id: 1468, name: 'Planxty Hewlett', url: 'https://thesession.org/tunes/1468', member: {…}, …}
+HomePage.js:45 Data for tune #263 {format: 'json', id: 263, name: 'Porthole Of The Kelp', url: 'https://thesession.org/tunes/263', member: {…}, …}
+HomePage.js:45 Data for tune #1077 {format: 'json', id: 1077, name: 'Munster Buttermilk', url: 'https://thesession.org/tunes/1077', member: {…}, …}
+HomePage.js:45 Data for tune #514 {format: 'json', id: 514, name: 'Down The Broom', url: 'https://thesession.org/tunes/514', member: {…}, …}
+HomePage.js:45 Data for tune #4428 {format: 'json', id: 4428, name: 'The High Drive', url: 'https://thesession.org/tunes/4428', member: {…}, …}
+HomePage.js:45 Data for tune #1716 {format: 'json', id: 1716, name: 'The Red-Haired Lass', url: 'https://thesession.org/tunes/1716', member: {…}, …}
+HomePage.js:45 Data for tune #736 {format: 'json', id: 736, name: 'Jump At The Sun', url: 'https://thesession.org/tunes/736', member: {…}, …}
+HomePage.js:45 Data for tune #2434 {format: 'json', id: 2434, name: "I'll Tell Me Ma", url: 'https://thesession.org/tunes/2434', member: {…}, …}
+HomePage.js:45 Data for tune #187 {format: 'json', id: 187, name: 'Far Away', url: 'https://thesession.org/tunes/187', member: {…}, …}
+HomePage.js:45 Data for tune #789 {format: 'json', id: 789, name: 'The Primrose Lasses', url: 'https://thesession.org/tunes/789', member: {…}, …}
+HomePage.js:45 Data for tune #948 {format: 'json', id: 948, name: 'Kitty Lie Over', url: 'https://thesession.org/tunes/948', member: {…}, …}
+HomePage.js:45 Data for tune #82 {format: 'json', id: 82, name: 'The Pride Of Petravore', url: 'https://thesession.org/tunes/82', member: {…}, …}
+HomePage.js:45 Data for tune #125 {format: 'json', id: 125, name: 'Within A Mile Of Dublin', url: 'https://thesession.org/tunes/125', member: {…}, …}
+HomePage.js:45 Data for tune #820 {format: 'json', id: 820, name: 'The Butlers Of Glen Avenue', url: 'https://thesession.org/tunes/820', member: {…}, …}
+HomePage.js:45 Data for tune #719 {format: 'json', id: 719, name: 'Rip The Calico', url: 'https://thesession.org/tunes/719', member: {…}, …}
+HomePage.js:45 Data for tune #1678 {format: 'json', id: 1678, name: "Margaret's", url: 'https://thesession.org/tunes/1678', member: {…}, …}
+HomePage.js:45 Data for tune #2639 {format: 'json', id: 2639, name: 'Ramnee Ceilidh', url: 'https://thesession.org/tunes/2639', member: {…}, …}
+HomePage.js:45 Data for tune #1301 {format: 'json', id: 1301, name: 'The Trip To Athlone', url: 'https://thesession.org/tunes/1301', member: {…}, …}
+HomePage.js:45 Data for tune #767 {format: 'json', id: 767, name: 'Farewell To Chernobyl', url: 'https://thesession.org/tunes/767', member: {…}, …}
+HomePage.js:45 Data for tune #376 {format: 'json', id: 376, name: 'The Providence', url: 'https://thesession.org/tunes/376', member: {…}, …}
+HomePage.js:45 Data for tune #1365 {format: 'json', id: 1365, name: 'The Blackberry Blossom', url: 'https://thesession.org/tunes/1365', member: {…}, …}
+HomePage.js:45 Data for tune #398 {format: 'json', id: 398, name: 'Pull The Knife And Stick It Again', url: 'https://thesession.org/tunes/398', member: {…}, …}
+HomePage.js:45 Data for tune #1263 {format: 'json', id: 1263, name: 'Her Long Dark Hair Flowing Down Her Back', url: 'https://thesession.org/tunes/1263', member: {…}, …}
+HomePage.js:45 Data for tune #537 {format: 'json', id: 537, name: 'The Creel Of Turf', url: 'https://thesession.org/tunes/537', member: {…}, …}
+HomePage.js:45 Data for tune #1070 {format: 'json', id: 1070, name: 'The Monaghan Twig', url: 'https://thesession.org/tunes/1070', member: {…}, …}
+HomePage.js:45 Data for tune #4403 {format: 'json', id: 4403, name: 'Farewell To Erin', url: 'https://thesession.org/tunes/4403', member: {…}, …}
+HomePage.js:45 Data for tune #5476 {format: 'json', id: 5476, name: "Sonny's", url: 'https://thesession.org/tunes/5476', member: {…}, …}
+HomePage.js:45 Data for tune #1133 {format: 'json', id: 1133, name: 'Off She Goes', url: 'https://thesession.org/tunes/1133', member: {…}, …}
+HomePage.js:45 Data for tune #843 {format: 'json', id: 843, name: "Christy Barry's", url: 'https://thesession.org/tunes/843', member: {…}, …}
+HomePage.js:45 Data for tune #1104 {format: 'json', id: 1104, name: 'The Blackbird', url: 'https://thesession.org/tunes/1104', member: {…}, …}
+HomePage.js:45 Data for tune #754 {format: 'json', id: 754, name: 'Bonnie Kate', url: 'https://thesession.org/tunes/754', member: {…}, …}
+HomePage.js:45 Data for tune #347 {format: 'json', id: 347, name: "Martin Wynne's", url: 'https://thesession.org/tunes/347', member: {…}, …}
+HomePage.js:45 Data for tune #1421 {format: 'json', id: 1421, name: "Carolan's Draught", url: 'https://thesession.org/tunes/1421', member: {…}, …}
+HomePage.js:45 Data for tune #3690 {format: 'json', id: 3690, name: 'The Skye Boat Song', url: 'https://thesession.org/tunes/3690', member: {…}, …}
+HomePage.js:45 Data for tune #883 {format: 'json', id: 883, name: 'The Laurel Tree', url: 'https://thesession.org/tunes/883', member: {…}, …}
+HomePage.js:45 Data for tune #333 {format: 'json', id: 333, name: "The Miller's Maggot", url: 'https://thesession.org/tunes/333', member: {…}, …}
+HomePage.js:45 Data for tune #483 {format: 'json', id: 483, name: 'Reel Béatrice', url: 'https://thesession.org/tunes/483', member: {…}, …}
+HomePage.js:45 Data for tune #463 {format: 'json', id: 463, name: "Paddy Fahey's", url: 'https://thesession.org/tunes/463', member: {…}, …}
+HomePage.js:45 Data for tune #711 {format: 'json', id: 711, name: 'The Tap Room', url: 'https://thesession.org/tunes/711', member: {…}, …}
+HomePage.js:45 Data for tune #870 {format: 'json', id: 870, name: 'Spórt', url: 'https://thesession.org/tunes/870', member: {…}, …}
+HomePage.js:45 Data for tune #840 {format: 'json', id: 840, name: 'The Chicago', url: 'https://thesession.org/tunes/840', member: {…}, …}
+HomePage.js:45 Data for tune #1754 {format: 'json', id: 1754, name: 'The Jolly Tinker', url: 'https://thesession.org/tunes/1754', member: {…}, …}
+react_devtools_backend.js:4026 Warning: Encountered two children with the same key, `1754`. Keys should be unique so that components maintain their identity across updates. Non-unique keys may cause children to be duplicated and/or omitted — the behavior is unsupported and could change in a future version.
+    at div
+    at div
+    at div
+    at InfiniteScroll (http://localhost:3000/static/js/bundle.js:83036:24)
+    at div
+    at HomePage (http://localhost:3000/static/js/bundle.js:566:5)
+    at Routes (http://localhost:3000/static/js/bundle.js:85572:5)
+    at Router (http://localhost:3000/static/js/bundle.js:85505:15)
+    at BrowserRouter (http://localhost:3000/static/js/bundle.js:84314:5)
+    at div
+    at App (http://localhost:3000/static/js/bundle.js:47:88)
+overrideMethod @ react_devtools_backend.js:4026
+printWarning @ react-dom.development.js:86
+error @ react-dom.development.js:60
+warnOnInvalidKey @ react-dom.development.js:15293
+reconcileChildrenArray @ react-dom.development.js:15330
+reconcileChildFibers @ react-dom.development.js:15821
+reconcileChildren @ react-dom.development.js:19174
+updateHostComponent @ react-dom.development.js:19924
+beginWork @ react-dom.development.js:21618
+beginWork$1 @ react-dom.development.js:27426
+performUnitOfWork @ react-dom.development.js:26557
+workLoopSync @ react-dom.development.js:26466
+renderRootSync @ react-dom.development.js:26434
+performConcurrentWorkOnRoot @ react-dom.development.js:25738
+workLoop @ scheduler.development.js:266
+flushWork @ scheduler.development.js:239
+performWorkUntilDeadline @ scheduler.development.js:533
+HomePage.js:45 Data for tune #2259 {format: 'json', id: 2259, name: 'The Legacy', url: 'https://thesession.org/tunes/2259', member: {…}, …}
+react_devtools_backend.js:4026 Warning: Encountered two children with the same key, `1754`. Keys should be unique so that components maintain their identity across updates. Non-unique keys may cause children to be duplicated and/or omitted — the behavior is unsupported and could change in a future version.
+    at div
+    at div
+    at div
+    at InfiniteScroll (http://localhost:3000/static/js/bundle.js:83036:24)
+    at div
+    at HomePage (http://localhost:3000/static/js/bundle.js:566:5)
+    at Routes (http://localhost:3000/static/js/bundle.js:85572:5)
+    at Router (http://localhost:3000/static/js/bundle.js:85505:15)
+    at BrowserRouter (http://localhost:3000/static/js/bundle.js:84314:5)
+    at div
+    at App (http://localhost:3000/static/js/bundle.js:47:88)
+overrideMethod @ react_devtools_backend.js:4026
+printWarning @ react-dom.development.js:86
+error @ react-dom.development.js:60
+warnOnInvalidKey @ react-dom.development.js:15293
+reconcileChildrenArray @ react-dom.development.js:15330
+reconcileChildFibers @ react-dom.development.js:15821
+reconcileChildren @ react-dom.development.js:19174
+updateHostComponent @ react-dom.development.js:19924
+beginWork @ react-dom.development.js:21618
+beginWork$1 @ react-dom.development.js:27426
+performUnitOfWork @ react-dom.development.js:26557
+workLoopSync @ react-dom.development.js:26466
+renderRootSync @ react-dom.development.js:26434
+performConcurrentWorkOnRoot @ react-dom.development.js:25738
+workLoop @ scheduler.development.js:266
+flushWork @ scheduler.development.js:239
+performWorkUntilDeadline @ scheduler.development.js:533
+HomePage.js:45 Data for tune #185 {format: 'json', id: 185, name: "Dinny Delaney's", url: 'https://thesession.org/tunes/185', member: {…}, …}
+HomePage.js:45 Data for tune #632 {format: 'json', id: 632, name: 'The Skylark', url: 'https://thesession.org/tunes/632', member: {…}, …}
+react_devtools_backend.js:4026 Warning: Encountered two children with the same key, `1754`. Keys should be unique so that components maintain their identity across updates. Non-unique keys may cause children to be duplicated and/or omitted — the behavior is unsupported and could change in a future version.
+    at div
+    at div
+    at div
+    at InfiniteScroll (http://localhost:3000/static/js/bundle.js:83036:24)
+    at div
+    at HomePage (http://localhost:3000/static/js/bundle.js:566:5)
+    at Routes (http://localhost:3000/static/js/bundle.js:85572:5)
+    at Router (http://localhost:3000/static/js/bundle.js:85505:15)
+    at BrowserRouter (http://localhost:3000/static/js/bundle.js:84314:5)
+    at div
+    at App (http://localhost:3000/static/js/bundle.js:47:88)
+overrideMethod @ react_devtools_backend.js:4026
+printWarning @ react-dom.development.js:86
+error @ react-dom.development.js:60
+warnOnInvalidKey @ react-dom.development.js:15293
+reconcileChildrenArray @ react-dom.development.js:15330
+reconcileChildFibers @ react-dom.development.js:15821
+reconcileChildren @ react-dom.development.js:19174
+updateHostComponent @ react-dom.development.js:19924
+beginWork @ react-dom.development.js:21618
+beginWork$1 @ react-dom.development.js:27426
+performUnitOfWork @ react-dom.development.js:26557
+workLoopSync @ react-dom.development.js:26466
+renderRootSync @ react-dom.development.js:26434
+performConcurrentWorkOnRoot @ react-dom.development.js:25738
+workLoop @ scheduler.development.js:266
+flushWork @ scheduler.development.js:239
+performWorkUntilDeadline @ scheduler.development.js:533
+HomePage.js:45 Data for tune #724 {format: 'json', id: 724, name: 'The Galtee Rangers', url: 'https://thesession.org/tunes/724', member: {…}, …}
+HomePage.js:45 Data for tune #6655 {format: 'json', id: 6655, name: 'Mouse In The Kitchen', url: 'https://thesession.org/tunes/6655', member: {…}, …}
+HomePage.js:45 Data for tune #6195 {format: 'json', id: 6195, name: 'The Lonesome Boatman', url: 'https://thesession.org/tunes/6195', member: {…}, …}
+react_devtools_backend.js:4026 Warning: Encountered two children with the same key, `1754`. Keys should be unique so that components maintain their identity across updates. Non-unique keys may cause children to be duplicated and/or omitted — the behavior is unsupported and could change in a future version.
+    at div
+    at div
+    at div
+    at InfiniteScroll (http://localhost:3000/static/js/bundle.js:83036:24)
+    at div
+    at HomePage (http://localhost:3000/static/js/bundle.js:566:5)
+    at Routes (http://localhost:3000/static/js/bundle.js:85572:5)
+    at Router (http://localhost:3000/static/js/bundle.js:85505:15)
+    at BrowserRouter (http://localhost:3000/static/js/bundle.js:84314:5)
+    at div
+    at App (http://localhost:3000/static/js/bundle.js:47:88)
+overrideMethod @ react_devtools_backend.js:4026
+printWarning @ react-dom.development.js:86
+error @ react-dom.development.js:60
+warnOnInvalidKey @ react-dom.development.js:15293
+reconcileChildrenArray @ react-dom.development.js:15330
+reconcileChildFibers @ react-dom.development.js:15821
+reconcileChildren @ react-dom.development.js:19174
+updateHostComponent @ react-dom.development.js:19924
+beginWork @ react-dom.development.js:21618
+beginWork$1 @ react-dom.development.js:27426
+performUnitOfWork @ react-dom.development.js:26557
+workLoopSync @ react-dom.development.js:26466
+renderRootSync @ react-dom.development.js:26434
+performConcurrentWorkOnRoot @ react-dom.development.js:25738
+workLoop @ scheduler.development.js:266
+flushWork @ scheduler.development.js:239
+performWorkUntilDeadline @ scheduler.development.js:533
+HomePage.js:45 Data for tune #1026 {format: 'json', id: 1026, name: "The Trip To Herve's", url: 'https://thesession.org/tunes/1026', member: {…}, …}
+HomePage.js:45 Data for tune #615 {format: 'json', id: 615, name: 'The Shaskeen', url: 'https://thesession.org/tunes/615', member: {…}, …}
+react_devtools_backend.js:4026 Warning: Encountered two children with the same key, `1754`. Keys should be unique so that components maintain their identity across updates. Non-unique keys may cause children to be duplicated and/or omitted — the behavior is unsupported and could change in a future version.
+    at div
+    at div
+    at div
+    at InfiniteScroll (http://localhost:3000/static/js/bundle.js:83036:24)
+    at div
+    at HomePage (http://localhost:3000/static/js/bundle.js:566:5)
+    at Routes (http://localhost:3000/static/js/bundle.js:85572:5)
+    at Router (http://localhost:3000/static/js/bundle.js:85505:15)
+    at BrowserRouter (http://localhost:3000/static/js/bundle.js:84314:5)
+    at div
+    at App (http://localhost:3000/static/js/bundle.js:47:88)
+overrideMethod @ react_devtools_backend.js:4026
+printWarning @ react-dom.development.js:86
+error @ react-dom.development.js:60
+warnOnInvalidKey @ react-dom.development.js:15293
+reconcileChildrenArray @ react-dom.development.js:15330
+reconcileChildFibers @ react-dom.development.js:15821
+reconcileChildren @ react-dom.development.js:19174
+updateHostComponent @ react-dom.development.js:19924
+beginWork @ react-dom.development.js:21618
+beginWork$1 @ react-dom.development.js:27426
+performUnitOfWork @ react-dom.development.js:26557
+workLoopSync @ react-dom.development.js:26466
+renderRootSync @ react-dom.development.js:26434
+performConcurrentWorkOnRoot @ react-dom.development.js:25738
+workLoop @ scheduler.development.js:266
+flushWork @ scheduler.development.js:239
+performWorkUntilDeadline @ scheduler.development.js:533
+HomePage.js:45 Data for tune #1554 {format: 'json', id: 1554, name: 'The Yellow Tinker', url: 'https://thesession.org/tunes/1554', member: {…}, …}
+HomePage.js:45 Data for tune #885 {format: 'json', id: 885, name: "The Wizard's Walk", url: 'https://thesession.org/tunes/885', member: {…}, …}
+react_devtools_backend.js:4026 Warning: Encountered two children with the same key, `1754`. Keys should be unique so that components maintain their identity across updates. Non-unique keys may cause children to be duplicated and/or omitted — the behavior is unsupported and could change in a future version.
+    at div
+    at div
+    at div
+    at InfiniteScroll (http://localhost:3000/static/js/bundle.js:83036:24)
+    at div
+    at HomePage (http://localhost:3000/static/js/bundle.js:566:5)
+    at Routes (http://localhost:3000/static/js/bundle.js:85572:5)
+    at Router (http://localhost:3000/static/js/bundle.js:85505:15)
+    at BrowserRouter (http://localhost:3000/static/js/bundle.js:84314:5)
+    at div
+    at App (http://localhost:3000/static/js/bundle.js:47:88)
+overrideMethod @ react_devtools_backend.js:4026
+printWarning @ react-dom.development.js:86
+error @ react-dom.development.js:60
+warnOnInvalidKey @ react-dom.development.js:15293
+reconcileChildrenArray @ react-dom.development.js:15330
+reconcileChildFibers @ react-dom.development.js:15821
+reconcileChildren @ react-dom.development.js:19174
+updateHostComponent @ react-dom.development.js:19924
+beginWork @ react-dom.development.js:21618
+beginWork$1 @ react-dom.development.js:27426
+performUnitOfWork @ react-dom.development.js:26557
+workLoopSync @ react-dom.development.js:26466
+renderRootSync @ react-dom.development.js:26434
+performConcurrentWorkOnRoot @ react-dom.development.js:25738
+workLoop @ scheduler.development.js:266
+flushWork @ scheduler.development.js:239
+performWorkUntilDeadline @ scheduler.development.js:533
+HomePage.js:45 Data for tune #729 {format: 'json', id: 729, name: "Siobhan O'Donnell's", url: 'https://thesession.org/tunes/729', member: {…}, …}
+HomePage.js:45 Data for tune #6867 {format: 'json', id: 6867, name: 'The Derry Air', url: 'https://thesession.org/tunes/6867', member: {…}, …}
+react_devtools_backend.js:4026 Warning: Encountered two children with the same key, `1754`. Keys should be unique so that components maintain their identity across updates. Non-unique keys may cause children to be duplicated and/or omitted — the behavior is unsupported and could change in a future version.
+    at div
+    at div
+    at div
+    at InfiniteScroll (http://localhost:3000/static/js/bundle.js:83036:24)
+    at div
+    at HomePage (http://localhost:3000/static/js/bundle.js:566:5)
+    at Routes (http://localhost:3000/static/js/bundle.js:85572:5)
+    at Router (http://localhost:3000/static/js/bundle.js:85505:15)
+    at BrowserRouter (http://localhost:3000/static/js/bundle.js:84314:5)
+    at div
+    at App (http://localhost:3000/static/js/bundle.js:47:88)
+overrideMethod @ react_devtools_backend.js:4026
+printWarning @ react-dom.development.js:86
+error @ react-dom.development.js:60
+warnOnInvalidKey @ react-dom.development.js:15293
+reconcileChildrenArray @ react-dom.development.js:15330
+reconcileChildFibers @ react-dom.development.js:15821
+reconcileChildren @ react-dom.development.js:19174
+updateHostComponent @ react-dom.development.js:19924
+beginWork @ react-dom.development.js:21618
+beginWork$1 @ react-dom.development.js:27426
+performUnitOfWork @ react-dom.development.js:26557
+workLoopSync @ react-dom.development.js:26466
+renderRootSync @ react-dom.development.js:26434
+performConcurrentWorkOnRoot @ react-dom.development.js:25738
+workLoop @ scheduler.development.js:266
+flushWork @ scheduler.development.js:239
+performWorkUntilDeadline @ scheduler.development.js:533
+HomePage.js:45 Data for tune #90 {format: 'json', id: 90, name: "O'Rourke's", url: 'https://thesession.org/tunes/90', member: {…}, …}
+HomePage.js:45 Data for tune #1049 {format: 'json', id: 1049, name: 'The Pipe On The Hob', url: 'https://thesession.org/tunes/1049', member: {…}, …}
+HomePage.js:45 Data for tune #2224 {format: 'json', id: 2224, name: 'The Stack Of Barley', url: 'https://thesession.org/tunes/2224', member: {…}, …}
+react_devtools_backend.js:4026 Warning: Encountered two children with the same key, `1754`. Keys should be unique so that components maintain their identity across updates. Non-unique keys may cause children to be duplicated and/or omitted — the behavior is unsupported and could change in a future version.
+    at div
+    at div
+    at div
+    at InfiniteScroll (http://localhost:3000/static/js/bundle.js:83036:24)
+    at div
+    at HomePage (http://localhost:3000/static/js/bundle.js:566:5)
+    at Routes (http://localhost:3000/static/js/bundle.js:85572:5)
+    at Router (http://localhost:3000/static/js/bundle.js:85505:15)
+    at BrowserRouter (http://localhost:3000/static/js/bundle.js:84314:5)
+    at div
+    at App (http://localhost:3000/static/js/bundle.js:47:88)
+overrideMethod @ react_devtools_backend.js:4026
+printWarning @ react-dom.development.js:86
+error @ react-dom.development.js:60
+warnOnInvalidKey @ react-dom.development.js:15293
+reconcileChildrenArray @ react-dom.development.js:15330
+reconcileChildFibers @ react-dom.development.js:15821
+reconcileChildren @ react-dom.development.js:19174
+updateHostComponent @ react-dom.development.js:19924
+beginWork @ react-dom.development.js:21618
+beginWork$1 @ react-dom.development.js:27426
+performUnitOfWork @ react-dom.development.js:26557
+workLoopSync @ react-dom.development.js:26466
+renderRootSync @ react-dom.development.js:26434
+performConcurrentWorkOnRoot @ react-dom.development.js:25738
+workLoop @ scheduler.development.js:266
+flushWork @ scheduler.development.js:239
+performWorkUntilDeadline @ scheduler.development.js:533
+HomePage.js:45 Data for tune #292 {format: 'json', id: 292, name: 'Willafjord', url: 'https://thesession.org/tunes/292', member: {…}, …}
+react_devtools_backend.js:4026 Warning: Encountered two children with the same key, `1754`. Keys should be unique so that components maintain their identity across updates. Non-unique keys may cause children to be duplicated and/or omitted — the behavior is unsupported and could change in a future version.
+    at div
+    at div
+    at div
+    at InfiniteScroll (http://localhost:3000/static/js/bundle.js:83036:24)
+    at div
+    at HomePage (http://localhost:3000/static/js/bundle.js:566:5)
+    at Routes (http://localhost:3000/static/js/bundle.js:85572:5)
+    at Router (http://localhost:3000/static/js/bundle.js:85505:15)
+    at BrowserRouter (http://localhost:3000/static/js/bundle.js:84314:5)
+    at div
+    at App (http://localhost:3000/static/js/bundle.js:47:88)
+overrideMethod @ react_devtools_backend.js:4026
+printWarning @ react-dom.development.js:86
+error @ react-dom.development.js:60
+warnOnInvalidKey @ react-dom.development.js:15293
+reconcileChildrenArray @ react-dom.development.js:15330
+reconcileChildFibers @ react-dom.development.js:15821
+reconcileChildren @ react-dom.development.js:19174
+updateHostComponent @ react-dom.development.js:19924
+beginWork @ react-dom.development.js:21618
+beginWork$1 @ react-dom.development.js:27426
+performUnitOfWork @ react-dom.development.js:26557
+workLoopSync @ react-dom.development.js:26466
+renderRootSync @ react-dom.development.js:26434
+performConcurrentWorkOnRoot @ react-dom.development.js:25738
+workLoop @ scheduler.development.js:266
+flushWork @ scheduler.development.js:239
+performWorkUntilDeadline @ scheduler.development.js:533
+HomePage.js:45 Data for tune #385 {format: 'json', id: 385, name: "Saint Patrick's Day", url: 'https://thesession.org/tunes/385', member: {…}, …}
+HomePage.js:45 Data for tune #207 {format: 'json', id: 207, name: 'Bunker Hill', url: 'https://thesession.org/tunes/207', member: {…}, …}
+HomePage.js:45 Data for tune #594 {format: 'json', id: 594, name: 'The Jug Of Punch', url: 'https://thesession.org/tunes/594', member: {…}, …}
+react_devtools_backend.js:4026 Warning: Encountered two children with the same key, `1754`. Keys should be unique so that components maintain their identity across updates. Non-unique keys may cause children to be duplicated and/or omitted — the behavior is unsupported and could change in a future version.
+    at div
+    at div
+    at div
+    at InfiniteScroll (http://localhost:3000/static/js/bundle.js:83036:24)
+    at div
+    at HomePage (http://localhost:3000/static/js/bundle.js:566:5)
+    at Routes (http://localhost:3000/static/js/bundle.js:85572:5)
+    at Router (http://localhost:3000/static/js/bundle.js:85505:15)
+    at BrowserRouter (http://localhost:3000/static/js/bundle.js:84314:5)
+    at div
+    at App (http://localhost:3000/static/js/bundle.js:47:88)
+overrideMethod @ react_devtools_backend.js:4026
+printWarning @ react-dom.development.js:86
+error @ react-dom.development.js:60
+warnOnInvalidKey @ react-dom.development.js:15293
+reconcileChildrenArray @ react-dom.development.js:15330
+reconcileChildFibers @ react-dom.development.js:15821
+reconcileChildren @ react-dom.development.js:19174
+updateHostComponent @ react-dom.development.js:19924
+beginWork @ react-dom.development.js:21618
+beginWork$1 @ react-dom.development.js:27426
+performUnitOfWork @ react-dom.development.js:26557
+workLoopSync @ react-dom.development.js:26466
+renderRootSync @ react-dom.development.js:26434
+performConcurrentWorkOnRoot @ react-dom.development.js:25738
+workLoop @ scheduler.development.js:266
+flushWork @ scheduler.development.js:239
+performWorkUntilDeadline @ scheduler.development.js:533
+HomePage.js:45 Data for tune #999 {format: 'json', id: 999, name: "Dan Breen's", url: 'https://thesession.org/tunes/999', member: {…}, …}
+HomePage.js:45 Data for tune #442 {format: 'json', id: 442, name: 'The Flowers Of Red Hill', url: 'https://thesession.org/tunes/442', member: {…}, …}
+HomePage.js:45 Data for tune #553 {format: 'json', id: 553, name: "The Drunken Sailor's", url: 'https://thesession.org/tunes/553', member: {…}, …}
+react_devtools_backend.js:4026 Warning: Encountered two children with the same key, `1754`. Keys should be unique so that components maintain their identity across updates. Non-unique keys may cause children to be duplicated and/or omitted — the behavior is unsupported and could change in a future version.
+    at div
+    at div
+    at div
+    at InfiniteScroll (http://localhost:3000/static/js/bundle.js:83036:24)
+    at div
+    at HomePage (http://localhost:3000/static/js/bundle.js:566:5)
+    at Routes (http://localhost:3000/static/js/bundle.js:85572:5)
+    at Router (http://localhost:3000/static/js/bundle.js:85505:15)
+    at BrowserRouter (http://localhost:3000/static/js/bundle.js:84314:5)
+    at div
+    at App (http://localhost:3000/static/js/bundle.js:47:88)
+overrideMethod @ react_devtools_backend.js:4026
+printWarning @ react-dom.development.js:86
+error @ react-dom.development.js:60
+warnOnInvalidKey @ react-dom.development.js:15293
+reconcileChildrenArray @ react-dom.development.js:15330
+reconcileChildFibers @ react-dom.development.js:15821
+reconcileChildren @ react-dom.development.js:19174
+updateHostComponent @ react-dom.development.js:19924
+beginWork @ react-dom.development.js:21618
+beginWork$1 @ react-dom.development.js:27426
+performUnitOfWork @ react-dom.development.js:26557
+workLoopSync @ react-dom.development.js:26466
+renderRootSync @ react-dom.development.js:26434
+performConcurrentWorkOnRoot @ react-dom.development.js:25738
+workLoop @ scheduler.development.js:266
+flushWork @ scheduler.development.js:239
+performWorkUntilDeadline @ scheduler.development.js:533
+HomePage.js:45 Data for tune #9942 {format: 'json', id: 9942, name: 'Superfly', url: 'https://thesession.org/tunes/9942', member: {…}, …}
+HomePage.js:45 Data for tune #649 {format: 'json', id: 649, name: 'The Humours Of Lissadell', url: 'https://thesession.org/tunes/649', member: {…}, …}
+react_devtools_backend.js:4026 Warning: Encountered two children with the same key, `1754`. Keys should be unique so that components maintain their identity across updates. Non-unique keys may cause children to be duplicated and/or omitted — the behavior is unsupported and could change in a future version.
+    at div
+    at div
+    at div
+    at InfiniteScroll (http://localhost:3000/static/js/bundle.js:83036:24)
+    at div
+    at HomePage (http://localhost:3000/static/js/bundle.js:566:5)
+    at Routes (http://localhost:3000/static/js/bundle.js:85572:5)
+    at Router (http://localhost:3000/static/js/bundle.js:85505:15)
+    at BrowserRouter (http://localhost:3000/static/js/bundle.js:84314:5)
+    at div
+    at App (http://localhost:3000/static/js/bundle.js:47:88)
+overrideMethod @ react_devtools_backend.js:4026
+printWarning @ react-dom.development.js:86
+error @ react-dom.development.js:60
+warnOnInvalidKey @ react-dom.development.js:15293
+reconcileChildrenArray @ react-dom.development.js:15330
+reconcileChildFibers @ react-dom.development.js:15821
+reconcileChildren @ react-dom.development.js:19174
+updateHostComponent @ react-dom.development.js:19924
+beginWork @ react-dom.development.js:21618
+beginWork$1 @ react-dom.development.js:27426
+performUnitOfWork @ react-dom.development.js:26557
+workLoopSync @ react-dom.development.js:26466
+renderRootSync @ react-dom.development.js:26434
+performConcurrentWorkOnRoot @ react-dom.development.js:25738
+workLoop @ scheduler.development.js:266
+flushWork @ scheduler.development.js:239
+performWorkUntilDeadline @ scheduler.development.js:533
+HomePage.js:45 Data for tune #487 {format: 'json', id: 487, name: "Pachelbel's Frolics", url: 'https://thesession.org/tunes/487', member: {…}, …}
+react_devtools_backend.js:4026 Warning: Encountered two children with the same key, `1754`. Keys should be unique so that components maintain their identity across updates. Non-unique keys may cause children to be duplicated and/or omitted — the behavior is unsupported and could change in a future version.
+    at div
+    at div
+    at div
+    at InfiniteScroll (http://localhost:3000/static/js/bundle.js:83036:24)
+    at div
+    at HomePage (http://localhost:3000/static/js/bundle.js:566:5)
+    at Routes (http://localhost:3000/static/js/bundle.js:85572:5)
+    at Router (http://localhost:3000/static/js/bundle.js:85505:15)
+    at BrowserRouter (http://localhost:3000/static/js/bundle.js:84314:5)
+    at div
+    at App (http://localhost:3000/static/js/bundle.js:47:88)
+overrideMethod @ react_devtools_backend.js:4026
+printWarning @ react-dom.development.js:86
+error @ react-dom.development.js:60
+warnOnInvalidKey @ react-dom.development.js:15293
+reconcileChildrenArray @ react-dom.development.js:15330
+reconcileChildFibers @ react-dom.development.js:15821
+reconcileChildren @ react-dom.development.js:19174
+updateHostComponent @ react-dom.development.js:19924
+beginWork @ react-dom.development.js:21618
+beginWork$1 @ react-dom.development.js:27426
+performUnitOfWork @ react-dom.development.js:26557
+workLoopSync @ react-dom.development.js:26466
+renderRootSync @ react-dom.development.js:26434
+performConcurrentWorkOnRoot @ react-dom.development.js:25738
+workLoop @ scheduler.development.js:266
+flushWork @ scheduler.development.js:239
+performWorkUntilDeadline @ scheduler.development.js:533
+HomePage.js:45 Data for tune #531 {format: 'json', id: 531, name: 'The Ballydesmond', url: 'https://thesession.org/tunes/531', member: {…}, …}
+react_devtools_backend.js:4026 Warning: Encountered two children with the same key, `1754`. Keys should be unique so that components maintain their identity across updates. Non-unique keys may cause children to be duplicated and/or omitted — the behavior is unsupported and could change in a future version.
+    at div
+    at div
+    at div
+    at InfiniteScroll (http://localhost:3000/static/js/bundle.js:83036:24)
+    at div
+    at HomePage (http://localhost:3000/static/js/bundle.js:566:5)
+    at Routes (http://localhost:3000/static/js/bundle.js:85572:5)
+    at Router (http://localhost:3000/static/js/bundle.js:85505:15)
+    at BrowserRouter (http://localhost:3000/static/js/bundle.js:84314:5)
+    at div
+    at App (http://localhost:3000/static/js/bundle.js:47:88)
+overrideMethod @ react_devtools_backend.js:4026
+printWarning @ react-dom.development.js:86
+error @ react-dom.development.js:60
+warnOnInvalidKey @ react-dom.development.js:15293
+reconcileChildrenArray @ react-dom.development.js:15330
+reconcileChildFibers @ react-dom.development.js:15821
+reconcileChildren @ react-dom.development.js:19174
+updateHostComponent @ react-dom.development.js:19924
+beginWork @ react-dom.development.js:21618
+beginWork$1 @ react-dom.development.js:27426
+performUnitOfWork @ react-dom.development.js:26557
+workLoopSync @ react-dom.development.js:26466
+renderRootSync @ react-dom.development.js:26434
+performConcurrentWorkOnRoot @ react-dom.development.js:25738
+workLoop @ scheduler.development.js:266
+flushWork @ scheduler.development.js:239
+performWorkUntilDeadline @ scheduler.development.js:533
+HomePage.js:45 Data for tune #737 {format: 'json', id: 737, name: 'The Spike Island Lasses', url: 'https://thesession.org/tunes/737', member: {…}, …}
+HomePage.js:45 Data for tune #921 {format: 'json', id: 921, name: 'The Knotted Cord', url: 'https://thesession.org/tunes/921', member: {…}, …}
+react_devtools_backend.js:4026 Warning: Encountered two children with the same key, `1754`. Keys should be unique so that components maintain their identity across updates. Non-unique keys may cause children to be duplicated and/or omitted — the behavior is unsupported and could change in a future version.
+    at div
+    at div
+    at div
+    at InfiniteScroll (http://localhost:3000/static/js/bundle.js:83036:24)
+    at div
+    at HomePage (http://localhost:3000/static/js/bundle.js:566:5)
+    at Routes (http://localhost:3000/static/js/bundle.js:85572:5)
+    at Router (http://localhost:3000/static/js/bundle.js:85505:15)
+    at BrowserRouter (http://localhost:3000/static/js/bundle.js:84314:5)
+    at div
+    at App (http://localhost:3000/static/js/bundle.js:47:88)
+overrideMethod @ react_devtools_backend.js:4026
+printWarning @ react-dom.development.js:86
+error @ react-dom.development.js:60
+warnOnInvalidKey @ react-dom.development.js:15293
+reconcileChildrenArray @ react-dom.development.js:15330
+reconcileChildFibers @ react-dom.development.js:15821
+reconcileChildren @ react-dom.development.js:19174
+updateHostComponent @ react-dom.development.js:19924
+beginWork @ react-dom.development.js:21618
+beginWork$1 @ react-dom.development.js:27426
+performUnitOfWork @ react-dom.development.js:26557
+workLoopSync @ react-dom.development.js:26466
+renderRootSync @ react-dom.development.js:26434
+performConcurrentWorkOnRoot @ react-dom.development.js:25738
+workLoop @ scheduler.development.js:266
+flushWork @ scheduler.development.js:239
+performWorkUntilDeadline @ scheduler.development.js:533
+HomePage.js:45 Data for tune #1307 {format: 'json', id: 1307, name: "Lucy Farr's", url: 'https://thesession.org/tunes/1307', member: {…}, …}
+HomePage.js:45 Data for tune #1209 {format: 'json', id: 1209, name: 'Colonel Fraser', url: 'https://thesession.org/tunes/1209', member: {…}, …}
+react_devtools_backend.js:4026 Warning: Encountered two children with the same key, `1754`. Keys should be unique so that components maintain their identity across updates. Non-unique keys may cause children to be duplicated and/or omitted — the behavior is unsupported and could change in a future version.
+    at div
+    at div
+    at div
+    at InfiniteScroll (http://localhost:3000/static/js/bundle.js:83036:24)
+    at div
+    at HomePage (http://localhost:3000/static/js/bundle.js:566:5)
+    at Routes (http://localhost:3000/static/js/bundle.js:85572:5)
+    at Router (http://localhost:3000/static/js/bundle.js:85505:15)
+    at BrowserRouter (http://localhost:3000/static/js/bundle.js:84314:5)
+    at div
+    at App (http://localhost:3000/static/js/bundle.js:47:88)
+overrideMethod @ react_devtools_backend.js:4026
+printWarning @ react-dom.development.js:86
+error @ react-dom.development.js:60
+warnOnInvalidKey @ react-dom.development.js:15293
+reconcileChildrenArray @ react-dom.development.js:15330
+reconcileChildFibers @ react-dom.development.js:15821
+reconcileChildren @ react-dom.development.js:19174
+updateHostComponent @ react-dom.development.js:19924
+beginWork @ react-dom.development.js:21618
+beginWork$1 @ react-dom.development.js:27426
+performUnitOfWork @ react-dom.development.js:26557
+workLoopSync @ react-dom.development.js:26466
+renderRootSync @ react-dom.development.js:26434
+performConcurrentWorkOnRoot @ react-dom.development.js:25738
+workLoop @ scheduler.development.js:266
+flushWork @ scheduler.development.js:239
+performWorkUntilDeadline @ scheduler.development.js:533
+HomePage.js:45 Data for tune #196 {format: 'json', id: 196, name: 'The Contradiction', url: 'https://thesession.org/tunes/196', member: {…}, …}
+HomePage.js:45 Data for tune #406 {format: 'json', id: 406, name: "Lad O'Beirne's", url: 'https://thesession.org/tunes/406', member: {…}, …}
+react_devtools_backend.js:4026 Warning: Encountered two children with the same key, `1754`. Keys should be unique so that components maintain their identity across updates. Non-unique keys may cause children to be duplicated and/or omitted — the behavior is unsupported and could change in a future version.
+    at div
+    at div
+    at div
+    at InfiniteScroll (http://localhost:3000/static/js/bundle.js:83036:24)
+    at div
+    at HomePage (http://localhost:3000/static/js/bundle.js:566:5)
+    at Routes (http://localhost:3000/static/js/bundle.js:85572:5)
+    at Router (http://localhost:3000/static/js/bundle.js:85505:15)
+    at BrowserRouter (http://localhost:3000/static/js/bundle.js:84314:5)
+    at div
+    at App (http://localhost:3000/static/js/bundle.js:47:88)
+overrideMethod @ react_devtools_backend.js:4026
+printWarning @ react-dom.development.js:86
+error @ react-dom.development.js:60
+warnOnInvalidKey @ react-dom.development.js:15293
+reconcileChildrenArray @ react-dom.development.js:15330
+reconcileChildFibers @ react-dom.development.js:15821
+reconcileChildren @ react-dom.development.js:19174
+updateHostComponent @ react-dom.development.js:19924
+beginWork @ react-dom.development.js:21618
+beginWork$1 @ react-dom.development.js:27426
+performUnitOfWork @ react-dom.development.js:26557
+workLoopSync @ react-dom.development.js:26466
+renderRootSync @ react-dom.development.js:26434
+performConcurrentWorkOnRoot @ react-dom.development.js:25738
+workLoop @ scheduler.development.js:266
+flushWork @ scheduler.development.js:239
+performWorkUntilDeadline @ scheduler.development.js:533
+HomePage.js:45 Data for tune #327 {format: 'json', id: 327, name: 'Health To The Ladies', url: 'https://thesession.org/tunes/327', member: {…}, …}
+react_devtools_backend.js:4026 Warning: Encountered two children with the same key, `1754`. Keys should be unique so that components maintain their identity across updates. Non-unique keys may cause children to be duplicated and/or omitted — the behavior is unsupported and could change in a future version.
+    at div
+    at div
+    at div
+    at InfiniteScroll (http://localhost:3000/static/js/bundle.js:83036:24)
+    at div
+    at HomePage (http://localhost:3000/static/js/bundle.js:566:5)
+    at Routes (http://localhost:3000/static/js/bundle.js:85572:5)
+    at Router (http://localhost:3000/static/js/bundle.js:85505:15)
+    at BrowserRouter (http://localhost:3000/static/js/bundle.js:84314:5)
+    at div
+    at App (http://localhost:3000/static/js/bundle.js:47:88)
+overrideMethod @ react_devtools_backend.js:4026
+printWarning @ react-dom.development.js:86
+error @ react-dom.development.js:60
+warnOnInvalidKey @ react-dom.development.js:15293
+reconcileChildrenArray @ react-dom.development.js:15330
+reconcileChildFibers @ react-dom.development.js:15821
+reconcileChildren @ react-dom.development.js:19174
+updateHostComponent @ react-dom.development.js:19924
+beginWork @ react-dom.development.js:21618
+beginWork$1 @ react-dom.development.js:27426
+performUnitOfWork @ react-dom.development.js:26557
+workLoopSync @ react-dom.development.js:26466
+renderRootSync @ react-dom.development.js:26434
+performConcurrentWorkOnRoot @ react-dom.development.js:25738
+workLoop @ scheduler.development.js:266
+flushWork @ scheduler.development.js:239
+performWorkUntilDeadline @ scheduler.development.js:533
+HomePage.js:45 Data for tune #769 {format: 'json', id: 769, name: 'The Belles Of Tipperary', url: 'https://thesession.org/tunes/769', member: {…}, …}
+react_devtools_backend.js:4026 Warning: Encountered two children with the same key, `1754`. Keys should be unique so that components maintain their identity across updates. Non-unique keys may cause children to be duplicated and/or omitted — the behavior is unsupported and could change in a future version.
+    at div
+    at div
+    at div
+    at InfiniteScroll (http://localhost:3000/static/js/bundle.js:83036:24)
+    at div
+    at HomePage (http://localhost:3000/static/js/bundle.js:566:5)
+    at Routes (http://localhost:3000/static/js/bundle.js:85572:5)
+    at Router (http://localhost:3000/static/js/bundle.js:85505:15)
+    at BrowserRouter (http://localhost:3000/static/js/bundle.js:84314:5)
+    at div
+    at App (http://localhost:3000/static/js/bundle.js:47:88)
+overrideMethod @ react_devtools_backend.js:4026
+printWarning @ react-dom.development.js:86
+error @ react-dom.development.js:60
+warnOnInvalidKey @ react-dom.development.js:15293
+reconcileChildrenArray @ react-dom.development.js:15330
+reconcileChildFibers @ react-dom.development.js:15821
+reconcileChildren @ react-dom.development.js:19174
+updateHostComponent @ react-dom.development.js:19924
+beginWork @ react-dom.development.js:21618
+beginWork$1 @ react-dom.development.js:27426
+performUnitOfWork @ react-dom.development.js:26557
+workLoopSync @ react-dom.development.js:26466
+renderRootSync @ react-dom.development.js:26434
+performConcurrentWorkOnRoot @ react-dom.development.js:25738
+workLoop @ scheduler.development.js:266
+flushWork @ scheduler.development.js:239
+performWorkUntilDeadline @ scheduler.development.js:533
+HomePage.js:45 Data for tune #2540 {format: 'json', id: 2540, name: 'Drummond Castle', url: 'https://thesession.org/tunes/2540', member: {…}, …}
+HomePage.js:45 Data for tune #816 {format: 'json', id: 816, name: "Tom Billy's", url: 'https://thesession.org/tunes/816', member: {…}, …}
+HomePage.js:45 Data for tune #1272 {format: 'json', id: 1272, name: 'The College Groves', url: 'https://thesession.org/tunes/1272', member: {…}, …}
+HomePage.js:45 Data for tune #583 {format: 'json', id: 583, name: "The Rattlin' Bog", url: 'https://thesession.org/tunes/583', member: {…}, …}
+react_devtools_backend.js:4026 Warning: Encountered two children with the same key, `1754`. Keys should be unique so that components maintain their identity across updates. Non-unique keys may cause children to be duplicated and/or omitted — the behavior is unsupported and could change in a future version.
+    at div
+    at div
+    at div
+    at InfiniteScroll (http://localhost:3000/static/js/bundle.js:83036:24)
+    at div
+    at HomePage (http://localhost:3000/static/js/bundle.js:566:5)
+    at Routes (http://localhost:3000/static/js/bundle.js:85572:5)
+    at Router (http://localhost:3000/static/js/bundle.js:85505:15)
+    at BrowserRouter (http://localhost:3000/static/js/bundle.js:84314:5)
+    at div
+    at App (http://localhost:3000/static/js/bundle.js:47:88)
+overrideMethod @ react_devtools_backend.js:4026
+printWarning @ react-dom.development.js:86
+error @ react-dom.development.js:60
+warnOnInvalidKey @ react-dom.development.js:15293
+reconcileChildrenArray @ react-dom.development.js:15330
+reconcileChildFibers @ react-dom.development.js:15821
+reconcileChildren @ react-dom.development.js:19174
+updateHostComponent @ react-dom.development.js:19924
+beginWork @ react-dom.development.js:21618
+beginWork$1 @ react-dom.development.js:27426
+performUnitOfWork @ react-dom.development.js:26557
+workLoopSync @ react-dom.development.js:26466
+renderRootSync @ react-dom.development.js:26434
+performConcurrentWorkOnRoot @ react-dom.development.js:25738
+workLoop @ scheduler.development.js:266
+flushWork @ scheduler.development.js:239
+performWorkUntilDeadline @ scheduler.development.js:533
+HomePage.js:45 Data for tune #835 {format: 'json', id: 835, name: 'March Of The Kings Of Laois', url: 'https://thesession.org/tunes/835', member: {…}, …}
+react_devtools_backend.js:4026 Warning: Encountered two children with the same key, `1754`. Keys should be unique so that components maintain their identity across updates. Non-unique keys may cause children to be duplicated and/or omitted — the behavior is unsupported and could change in a future version.
+    at div
+    at div
+    at div
+    at InfiniteScroll (http://localhost:3000/static/js/bundle.js:83036:24)
+    at div
+    at HomePage (http://localhost:3000/static/js/bundle.js:566:5)
+    at Routes (http://localhost:3000/static/js/bundle.js:85572:5)
+    at Router (http://localhost:3000/static/js/bundle.js:85505:15)
+    at BrowserRouter (http://localhost:3000/static/js/bundle.js:84314:5)
+    at div
+    at App (http://localhost:3000/static/js/bundle.js:47:88)
+overrideMethod @ react_devtools_backend.js:4026
+printWarning @ react-dom.development.js:86
+error @ react-dom.development.js:60
+warnOnInvalidKey @ react-dom.development.js:15293
+reconcileChildrenArray @ react-dom.development.js:15330
+reconcileChildFibers @ react-dom.development.js:15821
+reconcileChildren @ react-dom.development.js:19174
+updateHostComponent @ react-dom.development.js:19924
+beginWork @ react-dom.development.js:21618
+beginWork$1 @ react-dom.development.js:27426
+performUnitOfWork @ react-dom.development.js:26557
+workLoopSync @ react-dom.development.js:26466
+renderRootSync @ react-dom.development.js:26434
+performConcurrentWorkOnRoot @ react-dom.development.js:25738
+workLoop @ scheduler.development.js:266
+flushWork @ scheduler.development.js:239
+performWorkUntilDeadline @ scheduler.development.js:533
+HomePage.js:45 Data for tune #284 {format: 'json', id: 284, name: 'The Cameronian', url: 'https://thesession.org/tunes/284', member: {…}, …}
+react_devtools_backend.js:4026 Warning: Encountered two children with the same key, `1754`. Keys should be unique so that components maintain their identity across updates. Non-unique keys may cause children to be duplicated and/or omitted — the behavior is unsupported and could change in a future version.
+    at div
+    at div
+    at div
+    at InfiniteScroll (http://localhost:3000/static/js/bundle.js:83036:24)
+    at div
+    at HomePage (http://localhost:3000/static/js/bundle.js:566:5)
+    at Routes (http://localhost:3000/static/js/bundle.js:85572:5)
+    at Router (http://localhost:3000/static/js/bundle.js:85505:15)
+    at BrowserRouter (http://localhost:3000/static/js/bundle.js:84314:5)
+    at div
+    at App (http://localhost:3000/static/js/bundle.js:47:88)
+overrideMethod @ react_devtools_backend.js:4026
+printWarning @ react-dom.development.js:86
+error @ react-dom.development.js:60
+warnOnInvalidKey @ react-dom.development.js:15293
+reconcileChildrenArray @ react-dom.development.js:15330
+reconcileChildFibers @ react-dom.development.js:15821
+reconcileChildren @ react-dom.development.js:19174
+updateHostComponent @ react-dom.development.js:19924
+beginWork @ react-dom.development.js:21618
+beginWork$1 @ react-dom.development.js:27426
+performUnitOfWork @ react-dom.development.js:26557
+workLoopSync @ react-dom.development.js:26466
+renderRootSync @ react-dom.development.js:26434
+performConcurrentWorkOnRoot @ react-dom.development.js:25738
+workLoop @ scheduler.development.js:266
+flushWork @ scheduler.development.js:239
+performWorkUntilDeadline @ scheduler.development.js:533
+HomePage.js:45 Data for tune #3016 {format: 'json', id: 3016, name: "Calum's Road", url: 'https://thesession.org/tunes/3016', member: {…}, …}
+HomePage.js:45 Data for tune #40 {format: 'json', id: 40, name: 'The Guns Of The Magnificent Seven', url: 'https://thesession.org/tunes/40', member: {…}, …}
+HomePage.js:45 Data for tune #1578 {format: 'json', id: 1578, name: 'The Lark In The Morning', url: 'https://thesession.org/tunes/1578', member: {…}, …}
+react_devtools_backend.js:4026 Warning: Encountered two children with the same key, `1754`. Keys should be unique so that components maintain their identity across updates. Non-unique keys may cause children to be duplicated and/or omitted — the behavior is unsupported and could change in a future version.
+    at div
+    at div
+    at div
+    at InfiniteScroll (http://localhost:3000/static/js/bundle.js:83036:24)
+    at div
+    at HomePage (http://localhost:3000/static/js/bundle.js:566:5)
+    at Routes (http://localhost:3000/static/js/bundle.js:85572:5)
+    at Router (http://localhost:3000/static/js/bundle.js:85505:15)
+    at BrowserRouter (http://localhost:3000/static/js/bundle.js:84314:5)
+    at div
+    at App (http://localhost:3000/static/js/bundle.js:47:88)
+overrideMethod @ react_devtools_backend.js:4026
+printWarning @ react-dom.development.js:86
+error @ react-dom.development.js:60
+warnOnInvalidKey @ react-dom.development.js:15293
+reconcileChildrenArray @ react-dom.development.js:15330
+reconcileChildFibers @ react-dom.development.js:15821
+reconcileChildren @ react-dom.development.js:19174
+updateHostComponent @ react-dom.development.js:19924
+beginWork @ react-dom.development.js:21618
+beginWork$1 @ react-dom.development.js:27426
+performUnitOfWork @ react-dom.development.js:26557
+workLoopSync @ react-dom.development.js:26466
+renderRootSync @ react-dom.development.js:26434
+performConcurrentWorkOnRoot @ react-dom.development.js:25738
+workLoop @ scheduler.development.js:266
+flushWork @ scheduler.development.js:239
+performWorkUntilDeadline @ scheduler.development.js:533
+HomePage.js:45 Data for tune #976 {format: 'json', id: 976, name: 'The Old Maids Of Galway', url: 'https://thesession.org/tunes/976', member: {…}, …}
+HomePage.js:45 Data for tune #143 {format: 'json', id: 143, name: 'The Traveller', url: 'https://thesession.org/tunes/143', member: {…}, …}
+react_devtools_backend.js:4026 Warning: Encountered two children with the same key, `1754`. Keys should be unique so that components maintain their identity across updates. Non-unique keys may cause children to be duplicated and/or omitted — the behavior is unsupported and could change in a future version.
+    at div
+    at div
+    at div
+    at InfiniteScroll (http://localhost:3000/static/js/bundle.js:83036:24)
+    at div
+    at HomePage (http://localhost:3000/static/js/bundle.js:566:5)
+    at Routes (http://localhost:3000/static/js/bundle.js:85572:5)
+    at Router (http://localhost:3000/static/js/bundle.js:85505:15)
+    at BrowserRouter (http://localhost:3000/static/js/bundle.js:84314:5)
+    at div
+    at App (http://localhost:3000/static/js/bundle.js:47:88)
+overrideMethod @ react_devtools_backend.js:4026
+printWarning @ react-dom.development.js:86
+error @ react-dom.development.js:60
+warnOnInvalidKey @ react-dom.development.js:15293
+reconcileChildrenArray @ react-dom.development.js:15330
+reconcileChildFibers @ react-dom.development.js:15821
+reconcileChildren @ react-dom.development.js:19174
+updateHostComponent @ react-dom.development.js:19924
+beginWork @ react-dom.development.js:21618
+beginWork$1 @ react-dom.development.js:27426
+performUnitOfWork @ react-dom.development.js:26557
+workLoopSync @ react-dom.development.js:26466
+renderRootSync @ react-dom.development.js:26434
+performConcurrentWorkOnRoot @ react-dom.development.js:25738
+workLoop @ scheduler.development.js:266
+flushWork @ scheduler.development.js:239
+performWorkUntilDeadline @ scheduler.development.js:533
+HomePage.js:45 Data for tune #705 {format: 'json', id: 705, name: 'Barrowburn', url: 'https://thesession.org/tunes/705', member: {…}, …}
+react_devtools_backend.js:4026 Warning: Encountered two children with the same key, `1754`. Keys should be unique so that components maintain their identity across updates. Non-unique keys may cause children to be duplicated and/or omitted — the behavior is unsupported and could change in a future version.
+    at div
+    at div
+    at div
+    at InfiniteScroll (http://localhost:3000/static/js/bundle.js:83036:24)
+    at div
+    at HomePage (http://localhost:3000/static/js/bundle.js:566:5)
+    at Routes (http://localhost:3000/static/js/bundle.js:85572:5)
+    at Router (http://localhost:3000/static/js/bundle.js:85505:15)
+    at BrowserRouter (http://localhost:3000/static/js/bundle.js:84314:5)
+    at div
+    at App (http://localhost:3000/static/js/bundle.js:47:88)
+overrideMethod @ react_devtools_backend.js:4026
+printWarning @ react-dom.development.js:86
+error @ react-dom.development.js:60
+warnOnInvalidKey @ react-dom.development.js:15293
+reconcileChildrenArray @ react-dom.development.js:15330
+reconcileChildFibers @ react-dom.development.js:15821
+reconcileChildren @ react-dom.development.js:19174
+updateHostComponent @ react-dom.development.js:19924
+beginWork @ react-dom.development.js:21618
+beginWork$1 @ react-dom.development.js:27426
+performUnitOfWork @ react-dom.development.js:26557
+workLoopSync @ react-dom.development.js:26466
+renderRootSync @ react-dom.development.js:26434
+performConcurrentWorkOnRoot @ react-dom.development.js:25738
+workLoop @ scheduler.development.js:266
+flushWork @ scheduler.development.js:239
+performWorkUntilDeadline @ scheduler.development.js:533
+HomePage.js:45 Data for tune #8085 {format: 'json', id: 8085, name: 'Leaving Uist', url: 'https://thesession.org/tunes/8085', member: {…}, …}
+react_devtools_backend.js:4026 Warning: Encountered two children with the same key, `1754`. Keys should be unique so that components maintain their identity across updates. Non-unique keys may cause children to be duplicated and/or omitted — the behavior is unsupported and could change in a future version.
+    at div
+    at div
+    at div
+    at InfiniteScroll (http://localhost:3000/static/js/bundle.js:83036:24)
+    at div
+    at HomePage (http://localhost:3000/static/js/bundle.js:566:5)
+    at Routes (http://localhost:3000/static/js/bundle.js:85572:5)
+    at Router (http://localhost:3000/static/js/bundle.js:85505:15)
+    at BrowserRouter (http://localhost:3000/static/js/bundle.js:84314:5)
+    at div
+    at App (http://localhost:3000/static/js/bundle.js:47:88)
+overrideMethod @ react_devtools_backend.js:4026
+printWarning @ react-dom.development.js:86
+error @ react-dom.development.js:60
+warnOnInvalidKey @ react-dom.development.js:15293
+reconcileChildrenArray @ react-dom.development.js:15330
+reconcileChildFibers @ react-dom.development.js:15821
+reconcileChildren @ react-dom.development.js:19174
+updateHostComponent @ react-dom.development.js:19924
+beginWork @ react-dom.development.js:21618
+beginWork$1 @ react-dom.development.js:27426
+performUnitOfWork @ react-dom.development.js:26557
+workLoopSync @ react-dom.development.js:26466
+renderRootSync @ react-dom.development.js:26434
+performConcurrentWorkOnRoot @ react-dom.development.js:25738
+workLoop @ scheduler.development.js:266
+flushWork @ scheduler.development.js:239
+performWorkUntilDeadline @ scheduler.development.js:533
+HomePage.js:45 Data for tune #391 {format: 'json', id: 391, name: 'The Bag Of Potatoes', url: 'https://thesession.org/tunes/391', member: {…}, …}
+HomePage.js:45 Data for tune #148 {format: 'json', id: 148, name: 'Dever The Dancer', url: 'https://thesession.org/tunes/148', member: {…}, …}
+HomePage.js:45 Data for tune #1500 {format: 'json', id: 1500, name: 'The Liverpool', url: 'https://thesession.org/tunes/1500', member: {…}, …}
+react_devtools_backend.js:4026 Warning: Encountered two children with the same key, `1754`. Keys should be unique so that components maintain their identity across updates. Non-unique keys may cause children to be duplicated and/or omitted — the behavior is unsupported and could change in a future version.
+    at div
+    at div
+    at div
+    at InfiniteScroll (http://localhost:3000/static/js/bundle.js:83036:24)
+    at div
+    at HomePage (http://localhost:3000/static/js/bundle.js:566:5)
+    at Routes (http://localhost:3000/static/js/bundle.js:85572:5)
+    at Router (http://localhost:3000/static/js/bundle.js:85505:15)
+    at BrowserRouter (http://localhost:3000/static/js/bundle.js:84314:5)
+    at div
+    at App (http://localhost:3000/static/js/bundle.js:47:88)
+overrideMethod @ react_devtools_backend.js:4026
+printWarning @ react-dom.development.js:86
+error @ react-dom.development.js:60
+warnOnInvalidKey @ react-dom.development.js:15293
+reconcileChildrenArray @ react-dom.development.js:15330
+reconcileChildFibers @ react-dom.development.js:15821
+reconcileChildren @ react-dom.development.js:19174
+updateHostComponent @ react-dom.development.js:19924
+beginWork @ react-dom.development.js:21618
+beginWork$1 @ react-dom.development.js:27426
+performUnitOfWork @ react-dom.development.js:26557
+workLoopSync @ react-dom.development.js:26466
+renderRootSync @ react-dom.development.js:26434
+performConcurrentWorkOnRoot @ react-dom.development.js:25738
+workLoop @ scheduler.development.js:266
+flushWork @ scheduler.development.js:239
+performWorkUntilDeadline @ scheduler.development.js:533
+HomePage.js:45 Data for tune #367 {format: 'json', id: 367, name: "Mayor Harrison's Fedora", url: 'https://thesession.org/tunes/367', member: {…}, …}
+HomePage.js:45 Data for tune #695 {format: 'json', id: 695, name: 'The Green Fields Of America', url: 'https://thesession.org/tunes/695', member: {…}, …}
+react_devtools_backend.js:4026 Warning: Encountered two children with the same key, `1754`. Keys should be unique so that components maintain their identity across updates. Non-unique keys may cause children to be duplicated and/or omitted — the behavior is unsupported and could change in a future version.
+    at div
+    at div
+    at div
+    at InfiniteScroll (http://localhost:3000/static/js/bundle.js:83036:24)
+    at div
+    at HomePage (http://localhost:3000/static/js/bundle.js:566:5)
+    at Routes (http://localhost:3000/static/js/bundle.js:85572:5)
+    at Router (http://localhost:3000/static/js/bundle.js:85505:15)
+    at BrowserRouter (http://localhost:3000/static/js/bundle.js:84314:5)
+    at div
+    at App (http://localhost:3000/static/js/bundle.js:47:88)
+overrideMethod @ react_devtools_backend.js:4026
+printWarning @ react-dom.development.js:86
+error @ react-dom.development.js:60
+warnOnInvalidKey @ react-dom.development.js:15293
+reconcileChildrenArray @ react-dom.development.js:15330
+reconcileChildFibers @ react-dom.development.js:15821
+reconcileChildren @ react-dom.development.js:19174
+updateHostComponent @ react-dom.development.js:19924
+beginWork @ react-dom.development.js:21618
+beginWork$1 @ react-dom.development.js:27426
+performUnitOfWork @ react-dom.development.js:26557
+workLoopSync @ react-dom.development.js:26466
+renderRootSync @ react-dom.development.js:26434
+performConcurrentWorkOnRoot @ react-dom.development.js:25738
+workLoop @ scheduler.development.js:266
+flushWork @ scheduler.development.js:239
+performWorkUntilDeadline @ scheduler.development.js:533
+HomePage.js:45 Data for tune #1807 {format: 'json', id: 1807, name: 'The Rainy Day', url: 'https://thesession.org/tunes/1807', member: {…}, …}
+react_devtools_backend.js:4026 Warning: Encountered two children with the same key, `1754`. Keys should be unique so that components maintain their identity across updates. Non-unique keys may cause children to be duplicated and/or omitted — the behavior is unsupported and could change in a future version.
+    at div
+    at div
+    at div
+    at InfiniteScroll (http://localhost:3000/static/js/bundle.js:83036:24)
+    at div
+    at HomePage (http://localhost:3000/static/js/bundle.js:566:5)
+    at Routes (http://localhost:3000/static/js/bundle.js:85572:5)
+    at Router (http://localhost:3000/static/js/bundle.js:85505:15)
+    at BrowserRouter (http://localhost:3000/static/js/bundle.js:84314:5)
+    at div
+    at App (http://localhost:3000/static/js/bundle.js:47:88)
+overrideMethod @ react_devtools_backend.js:4026
+printWarning @ react-dom.development.js:86
+error @ react-dom.development.js:60
+warnOnInvalidKey @ react-dom.development.js:15293
+reconcileChildrenArray @ react-dom.development.js:15330
+reconcileChildFibers @ react-dom.development.js:15821
+reconcileChildren @ react-dom.development.js:19174
+updateHostComponent @ react-dom.development.js:19924
+beginWork @ react-dom.development.js:21618
+beginWork$1 @ react-dom.development.js:27426
+performUnitOfWork @ react-dom.development.js:26557
+workLoopSync @ react-dom.development.js:26466
+renderRootSync @ react-dom.development.js:26434
+performConcurrentWorkOnRoot @ react-dom.development.js:25738
+workLoop @ scheduler.development.js:266
+flushWork @ scheduler.development.js:239
+performWorkUntilDeadline @ scheduler.development.js:533
+HomePage.js:45 Data for tune #325 {format: 'json', id: 325, name: "Patsy Geary's", url: 'https://thesession.org/tunes/325', member: {…}, …}
+HomePage.js:45 Data for tune #1340 {format: 'json', id: 1340, name: 'The Boys Of Ballisodare', url: 'https://thesession.org/tunes/1340', member: {…}, …}
+HomePage.js:45 Data for tune #2266 {format: 'json', id: 2266, name: "Aaron's Key", url: 'https://thesession.org/tunes/2266', member: {…}, …}
+HomePage.js:45 Data for tune #1621 {format: 'json', id: 1621, name: 'The Donegal', url: 'https://thesession.org/tunes/1621', member: {…}, …}
+HomePage.js:45 Data for tune #280 {format: 'json', id: 280, name: 'Seanamhac Tube Station', url: 'https://thesession.org/tunes/280', member: {…}, …}
+react_devtools_backend.js:4026 Warning: Encountered two children with the same key, `1754`. Keys should be unique so that components maintain their identity across updates. Non-unique keys may cause children to be duplicated and/or omitted — the behavior is unsupported and could change in a future version.
+    at div
+    at div
+    at div
+    at InfiniteScroll (http://localhost:3000/static/js/bundle.js:83036:24)
+    at div
+    at HomePage (http://localhost:3000/static/js/bundle.js:566:5)
+    at Routes (http://localhost:3000/static/js/bundle.js:85572:5)
+    at Router (http://localhost:3000/static/js/bundle.js:85505:15)
+    at BrowserRouter (http://localhost:3000/static/js/bundle.js:84314:5)
+    at div
+    at App (http://localhost:3000/static/js/bundle.js:47:88)
+overrideMethod @ react_devtools_backend.js:4026
+printWarning @ react-dom.development.js:86
+error @ react-dom.development.js:60
+warnOnInvalidKey @ react-dom.development.js:15293
+reconcileChildrenArray @ react-dom.development.js:15330
+reconcileChildFibers @ react-dom.development.js:15821
+reconcileChildren @ react-dom.development.js:19174
+updateHostComponent @ react-dom.development.js:19924
+beginWork @ react-dom.development.js:21618
+beginWork$1 @ react-dom.development.js:27426
+performUnitOfWork @ react-dom.development.js:26557
+workLoopSync @ react-dom.development.js:26466
+renderRootSync @ react-dom.development.js:26434
+performConcurrentWorkOnRoot @ react-dom.development.js:25738
+workLoop @ scheduler.development.js:266
+flushWork @ scheduler.development.js:239
+performWorkUntilDeadline @ scheduler.development.js:533
+HomePage.js:45 Data for tune #414 {format: 'json', id: 414, name: "Seamus Cooley's", url: 'https://thesession.org/tunes/414', member: {…}, …}
+HomePage.js:45 Data for tune #864 {format: 'json', id: 864, name: 'The Cordal', url: 'https://thesession.org/tunes/864', member: {…}, …}
+HomePage.js:45 Data for tune #690 {format: 'json', id: 690, name: 'The Steampacket', url: 'https://thesession.org/tunes/690', member: {…}, …}
+HomePage.js:45 Data for tune #1097 {format: 'json', id: 1097, name: "Jack's The Lad", url: 'https://thesession.org/tunes/1097', member: {…}, …}
+react_devtools_backend.js:4026 Warning: Encountered two children with the same key, `1754`. Keys should be unique so that components maintain their identity across updates. Non-unique keys may cause children to be duplicated and/or omitted — the behavior is unsupported and could change in a future version.
+    at div
+    at div
+    at div
+    at InfiniteScroll (http://localhost:3000/static/js/bundle.js:83036:24)
+    at div
+    at HomePage (http://localhost:3000/static/js/bundle.js:566:5)
+    at Routes (http://localhost:3000/static/js/bundle.js:85572:5)
+    at Router (http://localhost:3000/static/js/bundle.js:85505:15)
+    at BrowserRouter (http://localhost:3000/static/js/bundle.js:84314:5)
+    at div
+    at App (http://localhost:3000/static/js/bundle.js:47:88)
+overrideMethod @ react_devtools_backend.js:4026
+printWarning @ react-dom.development.js:86
+error @ react-dom.development.js:60
+warnOnInvalidKey @ react-dom.development.js:15293
+reconcileChildrenArray @ react-dom.development.js:15330
+reconcileChildFibers @ react-dom.development.js:15821
+reconcileChildren @ react-dom.development.js:19174
+updateHostComponent @ react-dom.development.js:19924
+beginWork @ react-dom.development.js:21618
+beginWork$1 @ react-dom.development.js:27426
+performUnitOfWork @ react-dom.development.js:26557
+workLoopSync @ react-dom.development.js:26466
+renderRootSync @ react-dom.development.js:26434
+performConcurrentWorkOnRoot @ react-dom.development.js:25738
+workLoop @ scheduler.development.js:266
+flushWork @ scheduler.development.js:239
+performWorkUntilDeadline @ scheduler.development.js:533
+HomePage.js:45 Data for tune #841 {format: 'json', id: 841, name: "Poll Ha'Penny", url: 'https://thesession.org/tunes/841', member: {…}, …}
+HomePage.js:45 Data for tune #66 {format: 'json', id: 66, name: "Mulqueeney's", url: 'https://thesession.org/tunes/66', member: {…}, …}
+react_devtools_backend.js:4026 Warning: Encountered two children with the same key, `1754`. Keys should be unique so that components maintain their identity across updates. Non-unique keys may cause children to be duplicated and/or omitted — the behavior is unsupported and could change in a future version.
+    at div
+    at div
+    at div
+    at InfiniteScroll (http://localhost:3000/static/js/bundle.js:83036:24)
+    at div
+    at HomePage (http://localhost:3000/static/js/bundle.js:566:5)
+    at Routes (http://localhost:3000/static/js/bundle.js:85572:5)
+    at Router (http://localhost:3000/static/js/bundle.js:85505:15)
+    at BrowserRouter (http://localhost:3000/static/js/bundle.js:84314:5)
+    at div
+    at App (http://localhost:3000/static/js/bundle.js:47:88)
+overrideMethod @ react_devtools_backend.js:4026
+printWarning @ react-dom.development.js:86
+error @ react-dom.development.js:60
+warnOnInvalidKey @ react-dom.development.js:15293
+reconcileChildrenArray @ react-dom.development.js:15330
+reconcileChildFibers @ react-dom.development.js:15821
+reconcileChildren @ react-dom.development.js:19174
+updateHostComponent @ react-dom.development.js:19924
+beginWork @ react-dom.development.js:21618
+beginWork$1 @ react-dom.development.js:27426
+performUnitOfWork @ react-dom.development.js:26557
+workLoopSync @ react-dom.development.js:26466
+renderRootSync @ react-dom.development.js:26434
+performConcurrentWorkOnRoot @ react-dom.development.js:25738
+workLoop @ scheduler.development.js:266
+flushWork @ scheduler.development.js:239
+performWorkUntilDeadline @ scheduler.development.js:533
+HomePage.js:45 Data for tune #378 {format: 'json', id: 378, name: "Redican's Mother", url: 'https://thesession.org/tunes/378', member: {…}, …}
+HomePage.js:45 Data for tune #165 {format: 'json', id: 165, name: 'The Merry Sisters', url: 'https://thesession.org/tunes/165', member: {…}, …}
+HomePage.js:45 Data for tune #1462 {format: 'json', id: 1462, name: "The Hare's Paw", url: 'https://thesession.org/tunes/1462', member: {…}, …}
+react_devtools_backend.js:4026 Warning: Encountered two children with the same key, `1754`. Keys should be unique so that components maintain their identity across updates. Non-unique keys may cause children to be duplicated and/or omitted — the behavior is unsupported and could change in a future version.
+    at div
+    at div
+    at div
+    at InfiniteScroll (http://localhost:3000/static/js/bundle.js:83036:24)
+    at div
+    at HomePage (http://localhost:3000/static/js/bundle.js:566:5)
+    at Routes (http://localhost:3000/static/js/bundle.js:85572:5)
+    at Router (http://localhost:3000/static/js/bundle.js:85505:15)
+    at BrowserRouter (http://localhost:3000/static/js/bundle.js:84314:5)
+    at div
+    at App (http://localhost:3000/static/js/bundle.js:47:88)
+overrideMethod @ react_devtools_backend.js:4026
+printWarning @ react-dom.development.js:86
+error @ react-dom.development.js:60
+warnOnInvalidKey @ react-dom.development.js:15293
+reconcileChildrenArray @ react-dom.development.js:15330
+reconcileChildFibers @ react-dom.development.js:15821
+reconcileChildren @ react-dom.development.js:19174
+updateHostComponent @ react-dom.development.js:19924
+beginWork @ react-dom.development.js:21618
+beginWork$1 @ react-dom.development.js:27426
+performUnitOfWork @ react-dom.development.js:26557
+workLoopSync @ react-dom.development.js:26466
+renderRootSync @ react-dom.development.js:26434
+performConcurrentWorkOnRoot @ react-dom.development.js:25738
+workLoop @ scheduler.development.js:266
+flushWork @ scheduler.development.js:239
+performWorkUntilDeadline @ scheduler.development.js:533
+HomePage.js:45 Data for tune #663 {format: 'json', id: 663, name: "The Peacock's Feathers", url: 'https://thesession.org/tunes/663', member: {…}, …}
+HomePage.js:45 Data for tune #1030 {format: 'json', id: 1030, name: 'Comb Your Hair And Curl It', url: 'https://thesession.org/tunes/1030', member: {…}, …}
+HomePage.js:45 Data for tune #532 {format: 'json', id: 532, name: "Paddy Fahey's", url: 'https://thesession.org/tunes/532', member: {…}, …}
+react_devtools_backend.js:4026 Warning: Encountered two children with the same key, `1754`. Keys should be unique so that components maintain their identity across updates. Non-unique keys may cause children to be duplicated and/or omitted — the behavior is unsupported and could change in a future version.
+    at div
+    at div
+    at div
+    at InfiniteScroll (http://localhost:3000/static/js/bundle.js:83036:24)
+    at div
+    at HomePage (http://localhost:3000/static/js/bundle.js:566:5)
+    at Routes (http://localhost:3000/static/js/bundle.js:85572:5)
+    at Router (http://localhost:3000/static/js/bundle.js:85505:15)
+    at BrowserRouter (http://localhost:3000/static/js/bundle.js:84314:5)
+    at div
+    at App (http://localhost:3000/static/js/bundle.js:47:88)
+overrideMethod @ react_devtools_backend.js:4026
+printWarning @ react-dom.development.js:86
+error @ react-dom.development.js:60
+warnOnInvalidKey @ react-dom.development.js:15293
+reconcileChildrenArray @ react-dom.development.js:15330
+reconcileChildFibers @ react-dom.development.js:15821
+reconcileChildren @ react-dom.development.js:19174
+updateHostComponent @ react-dom.development.js:19924
+beginWork @ react-dom.development.js:21618
+beginWork$1 @ react-dom.development.js:27426
+performUnitOfWork @ react-dom.development.js:26557
+workLoopSync @ react-dom.development.js:26466
+renderRootSync @ react-dom.development.js:26434
+performConcurrentWorkOnRoot @ react-dom.development.js:25738
+workLoop @ scheduler.development.js:266
+flushWork @ scheduler.development.js:239
+performWorkUntilDeadline @ scheduler.development.js:533
+HomePage.js:45 Data for tune #1020 {format: 'json', id: 1020, name: "Palmer's Gate", url: 'https://thesession.org/tunes/1020', member: {…}, …}
+react_devtools_backend.js:4026 Warning: Encountered two children with the same key, `1754`. Keys should be unique so that components maintain their identity across updates. Non-unique keys may cause children to be duplicated and/or omitted — the behavior is unsupported and could change in a future version.
+    at div
+    at div
+    at div
+    at InfiniteScroll (http://localhost:3000/static/js/bundle.js:83036:24)
+    at div
+    at HomePage (http://localhost:3000/static/js/bundle.js:566:5)
+    at Routes (http://localhost:3000/static/js/bundle.js:85572:5)
+    at Router (http://localhost:3000/static/js/bundle.js:85505:15)
+    at BrowserRouter (http://localhost:3000/static/js/bundle.js:84314:5)
+    at div
+    at App (http://localhost:3000/static/js/bundle.js:47:88)
+overrideMethod @ react_devtools_backend.js:4026
+printWarning @ react-dom.development.js:86
+error @ react-dom.development.js:60
+warnOnInvalidKey @ react-dom.development.js:15293
+reconcileChildrenArray @ react-dom.development.js:15330
+reconcileChildFibers @ react-dom.development.js:15821
+reconcileChildren @ react-dom.development.js:19174
+updateHostComponent @ react-dom.development.js:19924
+beginWork @ react-dom.development.js:21618
+beginWork$1 @ react-dom.development.js:27426
+performUnitOfWork @ react-dom.development.js:26557
+workLoopSync @ react-dom.development.js:26466
+renderRootSync @ react-dom.development.js:26434
+performConcurrentWorkOnRoot @ react-dom.development.js:25738
+workLoop @ scheduler.development.js:266
+flushWork @ scheduler.development.js:239
+performWorkUntilDeadline @ scheduler.development.js:533
+HomePage.js:45 Data for tune #1831 {format: 'json', id: 1831, name: 'The Maid On The Green', url: 'https://thesession.org/tunes/1831', member: {…}, …}
+HomePage.js:45 Data for tune #3842 {format: 'json', id: 3842, name: 'The Lisnagun', url: 'https://thesession.org/tunes/3842', member: {…}, …}
+react_devtools_backend.js:4026 Warning: Encountered two children with the same key, `1754`. Keys should be unique so that components maintain their identity across updates. Non-unique keys may cause children to be duplicated and/or omitted — the behavior is unsupported and could change in a future version.
+    at div
+    at div
+    at div
+    at InfiniteScroll (http://localhost:3000/static/js/bundle.js:83036:24)
+    at div
+    at HomePage (http://localhost:3000/static/js/bundle.js:566:5)
+    at Routes (http://localhost:3000/static/js/bundle.js:85572:5)
+    at Router (http://localhost:3000/static/js/bundle.js:85505:15)
+    at BrowserRouter (http://localhost:3000/static/js/bundle.js:84314:5)
+    at div
+    at App (http://localhost:3000/static/js/bundle.js:47:88)
+overrideMethod @ react_devtools_backend.js:4026
+printWarning @ react-dom.development.js:86
+error @ react-dom.development.js:60
+warnOnInvalidKey @ react-dom.development.js:15293
+reconcileChildrenArray @ react-dom.development.js:15330
+reconcileChildFibers @ react-dom.development.js:15821
+reconcileChildren @ react-dom.development.js:19174
+updateHostComponent @ react-dom.development.js:19924
+beginWork @ react-dom.development.js:21618
+beginWork$1 @ react-dom.development.js:27426
+performUnitOfWork @ react-dom.development.js:26557
+workLoopSync @ react-dom.development.js:26466
+renderRootSync @ react-dom.development.js:26434
+performConcurrentWorkOnRoot @ react-dom.development.js:25738
+workLoop @ scheduler.development.js:266
+flushWork @ scheduler.development.js:239
+performWorkUntilDeadline @ scheduler.development.js:533
+HomePage.js:45 Data for tune #7425 {format: 'json', id: 7425, name: 'The Sleeping Tune', url: 'https://thesession.org/tunes/7425', member: {…}, …}
+HomePage.js:45 Data for tune #457 {format: 'json', id: 457, name: 'The Floating Crowbar', url: 'https://thesession.org/tunes/457', member: {…}, …}
+HomePage.js:45 Data for tune #851 {format: 'json', id: 851, name: 'Return From Fingal', url: 'https://thesession.org/tunes/851', member: {…}, …}
+react_devtools_backend.js:4026 Warning: Encountered two children with the same key, `1754`. Keys should be unique so that components maintain their identity across updates. Non-unique keys may cause children to be duplicated and/or omitted — the behavior is unsupported and could change in a future version.
+    at div
+    at div
+    at div
+    at InfiniteScroll (http://localhost:3000/static/js/bundle.js:83036:24)
+    at div
+    at HomePage (http://localhost:3000/static/js/bundle.js:566:5)
+    at Routes (http://localhost:3000/static/js/bundle.js:85572:5)
+    at Router (http://localhost:3000/static/js/bundle.js:85505:15)
+    at BrowserRouter (http://localhost:3000/static/js/bundle.js:84314:5)
+    at div
+    at App (http://localhost:3000/static/js/bundle.js:47:88)
+overrideMethod @ react_devtools_backend.js:4026
+printWarning @ react-dom.development.js:86
+error @ react-dom.development.js:60
+warnOnInvalidKey @ react-dom.development.js:15293
+reconcileChildrenArray @ react-dom.development.js:15330
+reconcileChildFibers @ react-dom.development.js:15821
+reconcileChildren @ react-dom.development.js:19174
+updateHostComponent @ react-dom.development.js:19924
+beginWork @ react-dom.development.js:21618
+beginWork$1 @ react-dom.development.js:27426
+performUnitOfWork @ react-dom.development.js:26557
+workLoopSync @ react-dom.development.js:26466
+renderRootSync @ react-dom.development.js:26434
+performConcurrentWorkOnRoot @ react-dom.development.js:25738
+workLoop @ scheduler.development.js:266
+flushWork @ scheduler.development.js:239
+performWorkUntilDeadline @ scheduler.development.js:533
+HomePage.js:45 Data for tune #3140 {format: 'json', id: 3140, name: "The Sailor's Wife", url: 'https://thesession.org/tunes/3140', member: {…}, …}
+react_devtools_backend.js:4026 Warning: Encountered two children with the same key, `1754`. Keys should be unique so that components maintain their identity across updates. Non-unique keys may cause children to be duplicated and/or omitted — the behavior is unsupported and could change in a future version.
+    at div
+    at div
+    at div
+    at InfiniteScroll (http://localhost:3000/static/js/bundle.js:83036:24)
+    at div
+    at HomePage (http://localhost:3000/static/js/bundle.js:566:5)
+    at Routes (http://localhost:3000/static/js/bundle.js:85572:5)
+    at Router (http://localhost:3000/static/js/bundle.js:85505:15)
+    at BrowserRouter (http://localhost:3000/static/js/bundle.js:84314:5)
+    at div
+    at App (http://localhost:3000/static/js/bundle.js:47:88)
+overrideMethod @ react_devtools_backend.js:4026
+printWarning @ react-dom.development.js:86
+error @ react-dom.development.js:60
+warnOnInvalidKey @ react-dom.development.js:15293
+reconcileChildrenArray @ react-dom.development.js:15330
+reconcileChildFibers @ react-dom.development.js:15821
+reconcileChildren @ react-dom.development.js:19174
+updateHostComponent @ react-dom.development.js:19924
+beginWork @ react-dom.development.js:21618
+beginWork$1 @ react-dom.development.js:27426
+performUnitOfWork @ react-dom.development.js:26557
+workLoopSync @ react-dom.development.js:26466
+renderRootSync @ react-dom.development.js:26434
+performConcurrentWorkOnRoot @ react-dom.development.js:25738
+workLoop @ scheduler.development.js:266
+flushWork @ scheduler.development.js:239
+performWorkUntilDeadline @ scheduler.development.js:533
+HomePage.js:45 Data for tune #787 {format: 'json', id: 787, name: 'Sleepy Maggie', url: 'https://thesession.org/tunes/787', member: {…}, …}
+HomePage.js:45 Data for tune #132 {format: 'json', id: 132, name: 'Eileen Curran', url: 'https://thesession.org/tunes/132', member: {…}, …}
+HomePage.js:45 Data for tune #1446 {format: 'json', id: 1446, name: 'The Eel In The Sink', url: 'https://thesession.org/tunes/1446', member: {…}, …}
+HomePage.js:45 Data for tune #1002 {format: 'json', id: 1002, name: 'Big John McNeil', url: 'https://thesession.org/tunes/1002', member: {…}, …}
+HomePage.js:45 Data for tune #223 {format: 'json', id: 223, name: 'The Last Pint', url: 'https://thesession.org/tunes/223', member: {…}, …}
+react_devtools_backend.js:4026 Warning: Encountered two children with the same key, `1754`. Keys should be unique so that components maintain their identity across updates. Non-unique keys may cause children to be duplicated and/or omitted — the behavior is unsupported and could change in a future version.
+    at div
+    at div
+    at div
+    at InfiniteScroll (http://localhost:3000/static/js/bundle.js:83036:24)
+    at div
+    at HomePage (http://localhost:3000/static/js/bundle.js:566:5)
+    at Routes (http://localhost:3000/static/js/bundle.js:85572:5)
+    at Router (http://localhost:3000/static/js/bundle.js:85505:15)
+    at BrowserRouter (http://localhost:3000/static/js/bundle.js:84314:5)
+    at div
+    at App (http://localhost:3000/static/js/bundle.js:47:88)
+overrideMethod @ react_devtools_backend.js:4026
+printWarning @ react-dom.development.js:86
+error @ react-dom.development.js:60
+warnOnInvalidKey @ react-dom.development.js:15293
+reconcileChildrenArray @ react-dom.development.js:15330
+reconcileChildFibers @ react-dom.development.js:15821
+reconcileChildren @ react-dom.development.js:19174
+updateHostComponent @ react-dom.development.js:19924
+beginWork @ react-dom.development.js:21618
+beginWork$1 @ react-dom.development.js:27426
+performUnitOfWork @ react-dom.development.js:26557
+workLoopSync @ react-dom.development.js:26466
+renderRootSync @ react-dom.development.js:26434
+performConcurrentWorkOnRoot @ react-dom.development.js:25738
+workLoop @ scheduler.development.js:266
+flushWork @ scheduler.development.js:239
+performWorkUntilDeadline @ scheduler.development.js:533
+HomePage.js:45 Data for tune #661 {format: 'json', id: 661, name: 'The Swaggering Jig', url: 'https://thesession.org/tunes/661', member: {…}, …}
+react_devtools_backend.js:4026 Warning: Encountered two children with the same key, `1754`. Keys should be unique so that components maintain their identity across updates. Non-unique keys may cause children to be duplicated and/or omitted — the behavior is unsupported and could change in a future version.
+    at div
+    at div
+    at div
+    at InfiniteScroll (http://localhost:3000/static/js/bundle.js:83036:24)
+    at div
+    at HomePage (http://localhost:3000/static/js/bundle.js:566:5)
+    at Routes (http://localhost:3000/static/js/bundle.js:85572:5)
+    at Router (http://localhost:3000/static/js/bundle.js:85505:15)
+    at BrowserRouter (http://localhost:3000/static/js/bundle.js:84314:5)
+    at div
+    at App (http://localhost:3000/static/js/bundle.js:47:88)
+overrideMethod @ react_devtools_backend.js:4026
+printWarning @ react-dom.development.js:86
+error @ react-dom.development.js:60
+warnOnInvalidKey @ react-dom.development.js:15293
+reconcileChildrenArray @ react-dom.development.js:15330
+reconcileChildFibers @ react-dom.development.js:15821
+reconcileChildren @ react-dom.development.js:19174
+updateHostComponent @ react-dom.development.js:19924
+beginWork @ react-dom.development.js:21618
+beginWork$1 @ react-dom.development.js:27426
+performUnitOfWork @ react-dom.development.js:26557
+workLoopSync @ react-dom.development.js:26466
+renderRootSync @ react-dom.development.js:26434
+performConcurrentWorkOnRoot @ react-dom.development.js:25738
+workLoop @ scheduler.development.js:266
+flushWork @ scheduler.development.js:239
+performWorkUntilDeadline @ scheduler.development.js:533
+HomePage.js:45 Data for tune #390 {format: 'json', id: 390, name: 'The Famous Ballymote', url: 'https://thesession.org/tunes/390', member: {…}, …}
+react_devtools_backend.js:4026 Warning: Encountered two children with the same key, `1754`. Keys should be unique so that components maintain their identity across updates. Non-unique keys may cause children to be duplicated and/or omitted — the behavior is unsupported and could change in a future version.
+    at div
+    at div
+    at div
+    at InfiniteScroll (http://localhost:3000/static/js/bundle.js:83036:24)
+    at div
+    at HomePage (http://localhost:3000/static/js/bundle.js:566:5)
+    at Routes (http://localhost:3000/static/js/bundle.js:85572:5)
+    at Router (http://localhost:3000/static/js/bundle.js:85505:15)
+    at BrowserRouter (http://localhost:3000/static/js/bundle.js:84314:5)
+    at div
+    at App (http://localhost:3000/static/js/bundle.js:47:88)
+overrideMethod @ react_devtools_backend.js:4026
+printWarning @ react-dom.development.js:86
+error @ react-dom.development.js:60
+warnOnInvalidKey @ react-dom.development.js:15293
+reconcileChildrenArray @ react-dom.development.js:15330
+reconcileChildFibers @ react-dom.development.js:15821
+reconcileChildren @ react-dom.development.js:19174
+updateHostComponent @ react-dom.development.js:19924
+beginWork @ react-dom.development.js:21618
+beginWork$1 @ react-dom.development.js:27426
+performUnitOfWork @ react-dom.development.js:26557
+workLoopSync @ react-dom.development.js:26466
+renderRootSync @ react-dom.development.js:26434
+performConcurrentWorkOnRoot @ react-dom.development.js:25738
+workLoop @ scheduler.development.js:266
+flushWork @ scheduler.development.js:239
+performWorkUntilDeadline @ scheduler.development.js:533
+HomePage.js:45 Data for tune #878 {format: 'json', id: 878, name: 'Da Full Rigged Ship', url: 'https://thesession.org/tunes/878', member: {…}, …}
+react_devtools_backend.js:4026 Warning: Encountered two children with the same key, `1754`. Keys should be unique so that components maintain their identity across updates. Non-unique keys may cause children to be duplicated and/or omitted — the behavior is unsupported and could change in a future version.
+    at div
+    at div
+    at div
+    at InfiniteScroll (http://localhost:3000/static/js/bundle.js:83036:24)
+    at div
+    at HomePage (http://localhost:3000/static/js/bundle.js:566:5)
+    at Routes (http://localhost:3000/static/js/bundle.js:85572:5)
+    at Router (http://localhost:3000/static/js/bundle.js:85505:15)
+    at BrowserRouter (http://localhost:3000/static/js/bundle.js:84314:5)
+    at div
+    at App (http://localhost:3000/static/js/bundle.js:47:88)
+overrideMethod @ react_devtools_backend.js:4026
+printWarning @ react-dom.development.js:86
+error @ react-dom.development.js:60
+warnOnInvalidKey @ react-dom.development.js:15293
+reconcileChildrenArray @ react-dom.development.js:15330
+reconcileChildFibers @ react-dom.development.js:15821
+reconcileChildren @ react-dom.development.js:19174
+updateHostComponent @ react-dom.development.js:19924
+beginWork @ react-dom.development.js:21618
+beginWork$1 @ react-dom.development.js:27426
+performUnitOfWork @ react-dom.development.js:26557
+workLoopSync @ react-dom.development.js:26466
+renderRootSync @ react-dom.development.js:26434
+performConcurrentWorkOnRoot @ react-dom.development.js:25738
+workLoop @ scheduler.development.js:266
+flushWork @ scheduler.development.js:239
+performWorkUntilDeadline @ scheduler.development.js:533
+HomePage.js:45 Data for tune #761 {format: 'json', id: 761, name: "Dowd's No. 9", url: 'https://thesession.org/tunes/761', member: {…}, …}
+HomePage.js:45 Data for tune #429 {format: 'json', id: 429, name: 'The Nine Points Of Roguery', url: 'https://thesession.org/tunes/429', member: {…}, …}
+react_devtools_backend.js:4026 Warning: Encountered two children with the same key, `1754`. Keys should be unique so that components maintain their identity across updates. Non-unique keys may cause children to be duplicated and/or omitted — the behavior is unsupported and could change in a future version.
+    at div
+    at div
+    at div
+    at InfiniteScroll (http://localhost:3000/static/js/bundle.js:83036:24)
+    at div
+    at HomePage (http://localhost:3000/static/js/bundle.js:566:5)
+    at Routes (http://localhost:3000/static/js/bundle.js:85572:5)
+    at Router (http://localhost:3000/static/js/bundle.js:85505:15)
+    at BrowserRouter (http://localhost:3000/static/js/bundle.js:84314:5)
+    at div
+    at App (http://localhost:3000/static/js/bundle.js:47:88)
+overrideMethod @ react_devtools_backend.js:4026
+printWarning @ react-dom.development.js:86
+error @ react-dom.development.js:60
+warnOnInvalidKey @ react-dom.development.js:15293
+reconcileChildrenArray @ react-dom.development.js:15330
+reconcileChildFibers @ react-dom.development.js:15821
+reconcileChildren @ react-dom.development.js:19174
+updateHostComponent @ react-dom.development.js:19924
+beginWork @ react-dom.development.js:21618
+beginWork$1 @ react-dom.development.js:27426
+performUnitOfWork @ react-dom.development.js:26557
+workLoopSync @ react-dom.development.js:26466
+renderRootSync @ react-dom.development.js:26434
+performConcurrentWorkOnRoot @ react-dom.development.js:25738
+workLoop @ scheduler.development.js:266
+flushWork @ scheduler.development.js:239
+performWorkUntilDeadline @ scheduler.development.js:533
+HomePage.js:45 Data for tune #455 {format: 'json', id: 455, name: 'Going To The Well For Water', url: 'https://thesession.org/tunes/455', member: {…}, …}
+react_devtools_backend.js:4026 Warning: Encountered two children with the same key, `1754`. Keys should be unique so that components maintain their identity across updates. Non-unique keys may cause children to be duplicated and/or omitted — the behavior is unsupported and could change in a future version.
+    at div
+    at div
+    at div
+    at InfiniteScroll (http://localhost:3000/static/js/bundle.js:83036:24)
+    at div
+    at HomePage (http://localhost:3000/static/js/bundle.js:566:5)
+    at Routes (http://localhost:3000/static/js/bundle.js:85572:5)
+    at Router (http://localhost:3000/static/js/bundle.js:85505:15)
+    at BrowserRouter (http://localhost:3000/static/js/bundle.js:84314:5)
+    at div
+    at App (http://localhost:3000/static/js/bundle.js:47:88)
+overrideMethod @ react_devtools_backend.js:4026
+printWarning @ react-dom.development.js:86
+error @ react-dom.development.js:60
+warnOnInvalidKey @ react-dom.development.js:15293
+reconcileChildrenArray @ react-dom.development.js:15330
+reconcileChildFibers @ react-dom.development.js:15821
+reconcileChildren @ react-dom.development.js:19174
+updateHostComponent @ react-dom.development.js:19924
+beginWork @ react-dom.development.js:21618
+beginWork$1 @ react-dom.development.js:27426
+performUnitOfWork @ react-dom.development.js:26557
+workLoopSync @ react-dom.development.js:26466
+renderRootSync @ react-dom.development.js:26434
+performConcurrentWorkOnRoot @ react-dom.development.js:25738
+workLoop @ scheduler.development.js:266
+flushWork @ scheduler.development.js:239
+performWorkUntilDeadline @ scheduler.development.js:533
+HomePage.js:45 Data for tune #4735 {format: 'json', id: 4735, name: 'She Moved Through The Fair', url: 'https://thesession.org/tunes/4735', member: {…}, …}
+react_devtools_backend.js:4026 Warning: Encountered two children with the same key, `1754`. Keys should be unique so that components maintain their identity across updates. Non-unique keys may cause children to be duplicated and/or omitted — the behavior is unsupported and could change in a future version.
+    at div
+    at div
+    at div
+    at InfiniteScroll (http://localhost:3000/static/js/bundle.js:83036:24)
+    at div
+    at HomePage (http://localhost:3000/static/js/bundle.js:566:5)
+    at Routes (http://localhost:3000/static/js/bundle.js:85572:5)
+    at Router (http://localhost:3000/static/js/bundle.js:85505:15)
+    at BrowserRouter (http://localhost:3000/static/js/bundle.js:84314:5)
+    at div
+    at App (http://localhost:3000/static/js/bundle.js:47:88)
+overrideMethod @ react_devtools_backend.js:4026
+printWarning @ react-dom.development.js:86
+error @ react-dom.development.js:60
+warnOnInvalidKey @ react-dom.development.js:15293
+reconcileChildrenArray @ react-dom.development.js:15330
+reconcileChildFibers @ react-dom.development.js:15821
+reconcileChildren @ react-dom.development.js:19174
+updateHostComponent @ react-dom.development.js:19924
+beginWork @ react-dom.development.js:21618
+beginWork$1 @ react-dom.development.js:27426
+performUnitOfWork @ react-dom.development.js:26557
+workLoopSync @ react-dom.development.js:26466
+renderRootSync @ react-dom.development.js:26434
+performConcurrentWorkOnRoot @ react-dom.development.js:25738
+workLoop @ scheduler.development.js:266
+flushWork @ scheduler.development.js:239
+performWorkUntilDeadline @ scheduler.development.js:533
+HomePage.js:45 Data for tune #1035 {format: 'json', id: 1035, name: 'The Boys Of The Town', url: 'https://thesession.org/tunes/1035', member: {…}, …}
+react_devtools_backend.js:4026 Warning: Encountered two children with the same key, `1754`. Keys should be unique so that components maintain their identity across updates. Non-unique keys may cause children to be duplicated and/or omitted — the behavior is unsupported and could change in a future version.
+    at div
+    at div
+    at div
+    at InfiniteScroll (http://localhost:3000/static/js/bundle.js:83036:24)
+    at div
+    at HomePage (http://localhost:3000/static/js/bundle.js:566:5)
+    at Routes (http://localhost:3000/static/js/bundle.js:85572:5)
+    at Router (http://localhost:3000/static/js/bundle.js:85505:15)
+    at BrowserRouter (http://localhost:3000/static/js/bundle.js:84314:5)
+    at div
+    at App (http://localhost:3000/static/js/bundle.js:47:88)
+overrideMethod @ react_devtools_backend.js:4026
+printWarning @ react-dom.development.js:86
+error @ react-dom.development.js:60
+warnOnInvalidKey @ react-dom.development.js:15293
+reconcileChildrenArray @ react-dom.development.js:15330
+reconcileChildFibers @ react-dom.development.js:15821
+reconcileChildren @ react-dom.development.js:19174
+updateHostComponent @ react-dom.development.js:19924
+beginWork @ react-dom.development.js:21618
+beginWork$1 @ react-dom.development.js:27426
+performUnitOfWork @ react-dom.development.js:26557
+workLoopSync @ react-dom.development.js:26466
+renderRootSync @ react-dom.development.js:26434
+performConcurrentWorkOnRoot @ react-dom.development.js:25738
+workLoop @ scheduler.development.js:266
+flushWork @ scheduler.development.js:239
+performWorkUntilDeadline @ scheduler.development.js:533
+HomePage.js:45 Data for tune #411 {format: 'json', id: 411, name: 'The Heather Breeze', url: 'https://thesession.org/tunes/411', member: {…}, …}
+HomePage.js:45 Data for tune #235 {format: 'json', id: 235, name: 'Sean Bui', url: 'https://thesession.org/tunes/235', member: {…}, …}
+react_devtools_backend.js:4026 Warning: Encountered two children with the same key, `1754`. Keys should be unique so that components maintain their identity across updates. Non-unique keys may cause children to be duplicated and/or omitted — the behavior is unsupported and could change in a future version.
+    at div
+    at div
+    at div
+    at InfiniteScroll (http://localhost:3000/static/js/bundle.js:83036:24)
+    at div
+    at HomePage (http://localhost:3000/static/js/bundle.js:566:5)
+    at Routes (http://localhost:3000/static/js/bundle.js:85572:5)
+    at Router (http://localhost:3000/static/js/bundle.js:85505:15)
+    at BrowserRouter (http://localhost:3000/static/js/bundle.js:84314:5)
+    at div
+    at App (http://localhost:3000/static/js/bundle.js:47:88)
+overrideMethod @ react_devtools_backend.js:4026
+printWarning @ react-dom.development.js:86
+error @ react-dom.development.js:60
+warnOnInvalidKey @ react-dom.development.js:15293
+reconcileChildrenArray @ react-dom.development.js:15330
+reconcileChildFibers @ react-dom.development.js:15821
+reconcileChildren @ react-dom.development.js:19174
+updateHostComponent @ react-dom.development.js:19924
+beginWork @ react-dom.development.js:21618
+beginWork$1 @ react-dom.development.js:27426
+performUnitOfWork @ react-dom.development.js:26557
+workLoopSync @ react-dom.development.js:26466
+renderRootSync @ react-dom.development.js:26434
+performConcurrentWorkOnRoot @ react-dom.development.js:25738
+workLoop @ scheduler.development.js:266
+flushWork @ scheduler.development.js:239
+performWorkUntilDeadline @ scheduler.development.js:533
+HomePage.js:45 Data for tune #2254 {format: 'json', id: 2254, name: 'The Hag At The Spinning Wheel', url: 'https://thesession.org/tunes/2254', member: {…}, …}
+HomePage.js:45 Data for tune #3110 {format: 'json', id: 3110, name: 'Helvic Head', url: 'https://thesession.org/tunes/3110', member: {…}, …}
+react_devtools_backend.js:4026 Warning: Encountered two children with the same key, `1754`. Keys should be unique so that components maintain their identity across updates. Non-unique keys may cause children to be duplicated and/or omitted — the behavior is unsupported and could change in a future version.
+    at div
+    at div
+    at div
+    at InfiniteScroll (http://localhost:3000/static/js/bundle.js:83036:24)
+    at div
+    at HomePage (http://localhost:3000/static/js/bundle.js:566:5)
+    at Routes (http://localhost:3000/static/js/bundle.js:85572:5)
+    at Router (http://localhost:3000/static/js/bundle.js:85505:15)
+    at BrowserRouter (http://localhost:3000/static/js/bundle.js:84314:5)
+    at div
+    at App (http://localhost:3000/static/js/bundle.js:47:88)
+overrideMethod @ react_devtools_backend.js:4026
+printWarning @ react-dom.development.js:86
+error @ react-dom.development.js:60
+warnOnInvalidKey @ react-dom.development.js:15293
+reconcileChildrenArray @ react-dom.development.js:15330
+reconcileChildFibers @ react-dom.development.js:15821
+reconcileChildren @ react-dom.development.js:19174
+updateHostComponent @ react-dom.development.js:19924
+beginWork @ react-dom.development.js:21618
+beginWork$1 @ react-dom.development.js:27426
+performUnitOfWork @ react-dom.development.js:26557
+workLoopSync @ react-dom.development.js:26466
+renderRootSync @ react-dom.development.js:26434
+performConcurrentWorkOnRoot @ react-dom.development.js:25738
+workLoop @ scheduler.development.js:266
+flushWork @ scheduler.development.js:239
+performWorkUntilDeadline @ scheduler.development.js:533
+HomePage.js:45 Data for tune #974 {format: 'json', id: 974, name: 'The Golden Eagle', url: 'https://thesession.org/tunes/974', member: {…}, …}
+HomePage.js:45 Data for tune #1581 {format: 'json', id: 1581, name: "McFadden's Handsome Daughter", url: 'https://thesession.org/tunes/1581', member: {…}, …}
+react_devtools_backend.js:4026 Warning: Encountered two children with the same key, `1754`. Keys should be unique so that components maintain their identity across updates. Non-unique keys may cause children to be duplicated and/or omitted — the behavior is unsupported and could change in a future version.
+    at div
+    at div
+    at div
+    at InfiniteScroll (http://localhost:3000/static/js/bundle.js:83036:24)
+    at div
+    at HomePage (http://localhost:3000/static/js/bundle.js:566:5)
+    at Routes (http://localhost:3000/static/js/bundle.js:85572:5)
+    at Router (http://localhost:3000/static/js/bundle.js:85505:15)
+    at BrowserRouter (http://localhost:3000/static/js/bundle.js:84314:5)
+    at div
+    at App (http://localhost:3000/static/js/bundle.js:47:88)
+overrideMethod @ react_devtools_backend.js:4026
+printWarning @ react-dom.development.js:86
+error @ react-dom.development.js:60
+warnOnInvalidKey @ react-dom.development.js:15293
+reconcileChildrenArray @ react-dom.development.js:15330
+reconcileChildFibers @ react-dom.development.js:15821
+reconcileChildren @ react-dom.development.js:19174
+updateHostComponent @ react-dom.development.js:19924
+beginWork @ react-dom.development.js:21618
+beginWork$1 @ react-dom.development.js:27426
+performUnitOfWork @ react-dom.development.js:26557
+workLoopSync @ react-dom.development.js:26466
+renderRootSync @ react-dom.development.js:26434
+performConcurrentWorkOnRoot @ react-dom.development.js:25738
+workLoop @ scheduler.development.js:266
+flushWork @ scheduler.development.js:239
+performWorkUntilDeadline @ scheduler.development.js:533
+HomePage.js:45 Data for tune #1746 {format: 'json', id: 1746, name: 'The Devil In The Kitchen', url: 'https://thesession.org/tunes/1746', member: {…}, …}
+react_devtools_backend.js:4026 Warning: Encountered two children with the same key, `1754`. Keys should be unique so that components maintain their identity across updates. Non-unique keys may cause children to be duplicated and/or omitted — the behavior is unsupported and could change in a future version.
+    at div
+    at div
+    at div
+    at InfiniteScroll (http://localhost:3000/static/js/bundle.js:83036:24)
+    at div
+    at HomePage (http://localhost:3000/static/js/bundle.js:566:5)
+    at Routes (http://localhost:3000/static/js/bundle.js:85572:5)
+    at Router (http://localhost:3000/static/js/bundle.js:85505:15)
+    at BrowserRouter (http://localhost:3000/static/js/bundle.js:84314:5)
+    at div
+    at App (http://localhost:3000/static/js/bundle.js:47:88)
+overrideMethod @ react_devtools_backend.js:4026
+printWarning @ react-dom.development.js:86
+error @ react-dom.development.js:60
+warnOnInvalidKey @ react-dom.development.js:15293
+reconcileChildrenArray @ react-dom.development.js:15330
+reconcileChildFibers @ react-dom.development.js:15821
+reconcileChildren @ react-dom.development.js:19174
+updateHostComponent @ react-dom.development.js:19924
+beginWork @ react-dom.development.js:21618
+beginWork$1 @ react-dom.development.js:27426
+performUnitOfWork @ react-dom.development.js:26557
+workLoopSync @ react-dom.development.js:26466
+renderRootSync @ react-dom.development.js:26434
+performConcurrentWorkOnRoot @ react-dom.development.js:25738
+workLoop @ scheduler.development.js:266
+flushWork @ scheduler.development.js:239
+performWorkUntilDeadline @ scheduler.development.js:533
+HomePage.js:45 Data for tune #417 {format: 'json', id: 417, name: "Arthur Darley's", url: 'https://thesession.org/tunes/417', member: {…}, …}
+HomePage.js:45 Data for tune #2025 {format: 'json', id: 2025, name: 'The Wandering Minstrel', url: 'https://thesession.org/tunes/2025', member: {…}, …}
+react_devtools_backend.js:4026 Warning: Encountered two children with the same key, `1754`. Keys should be unique so that components maintain their identity across updates. Non-unique keys may cause children to be duplicated and/or omitted — the behavior is unsupported and could change in a future version.
+    at div
+    at div
+    at div
+    at InfiniteScroll (http://localhost:3000/static/js/bundle.js:83036:24)
+    at div
+    at HomePage (http://localhost:3000/static/js/bundle.js:566:5)
+    at Routes (http://localhost:3000/static/js/bundle.js:85572:5)
+    at Router (http://localhost:3000/static/js/bundle.js:85505:15)
+    at BrowserRouter (http://localhost:3000/static/js/bundle.js:84314:5)
+    at div
+    at App (http://localhost:3000/static/js/bundle.js:47:88)
+overrideMethod @ react_devtools_backend.js:4026
+printWarning @ react-dom.development.js:86
+error @ react-dom.development.js:60
+warnOnInvalidKey @ react-dom.development.js:15293
+reconcileChildrenArray @ react-dom.development.js:15330
+reconcileChildFibers @ react-dom.development.js:15821
+reconcileChildren @ react-dom.development.js:19174
+updateHostComponent @ react-dom.development.js:19924
+beginWork @ react-dom.development.js:21618
+beginWork$1 @ react-dom.development.js:27426
+performUnitOfWork @ react-dom.development.js:26557
+workLoopSync @ react-dom.development.js:26466
+renderRootSync @ react-dom.development.js:26434
+performConcurrentWorkOnRoot @ react-dom.development.js:25738
+workLoop @ scheduler.development.js:266
+flushWork @ scheduler.development.js:239
+performWorkUntilDeadline @ scheduler.development.js:533
+HomePage.js:45 Data for tune #1385 {format: 'json', id: 1385, name: 'The Duke Of Leinster', url: 'https://thesession.org/tunes/1385', member: {…}, …}
+HomePage.js:45 Data for tune #1303 {format: 'json', id: 1303, name: "Paddy's Trip To Scotland", url: 'https://thesession.org/tunes/1303', member: {…}, …}
+HomePage.js:45 Data for tune #1347 {format: 'json', id: 1347, name: "Jenny's Wedding", url: 'https://thesession.org/tunes/1347', member: {…}, …}
+react_devtools_backend.js:4026 Warning: Encountered two children with the same key, `1754`. Keys should be unique so that components maintain their identity across updates. Non-unique keys may cause children to be duplicated and/or omitted — the behavior is unsupported and could change in a future version.
+    at div
+    at div
+    at div
+    at InfiniteScroll (http://localhost:3000/static/js/bundle.js:83036:24)
+    at div
+    at HomePage (http://localhost:3000/static/js/bundle.js:566:5)
+    at Routes (http://localhost:3000/static/js/bundle.js:85572:5)
+    at Router (http://localhost:3000/static/js/bundle.js:85505:15)
+    at BrowserRouter (http://localhost:3000/static/js/bundle.js:84314:5)
+    at div
+    at App (http://localhost:3000/static/js/bundle.js:47:88)
+overrideMethod @ react_devtools_backend.js:4026
+printWarning @ react-dom.development.js:86
+error @ react-dom.development.js:60
+warnOnInvalidKey @ react-dom.development.js:15293
+reconcileChildrenArray @ react-dom.development.js:15330
+reconcileChildFibers @ react-dom.development.js:15821
+reconcileChildren @ react-dom.development.js:19174
+updateHostComponent @ react-dom.development.js:19924
+beginWork @ react-dom.development.js:21618
+beginWork$1 @ react-dom.development.js:27426
+performUnitOfWork @ react-dom.development.js:26557
+workLoopSync @ react-dom.development.js:26466
+renderRootSync @ react-dom.development.js:26434
+performConcurrentWorkOnRoot @ react-dom.development.js:25738
+workLoop @ scheduler.development.js:266
+flushWork @ scheduler.development.js:239
+performWorkUntilDeadline @ scheduler.development.js:533
+HomePage.js:45 Data for tune #96 {format: 'json', id: 96, name: 'Scotch Mary', url: 'https://thesession.org/tunes/96', member: {…}, …}
+react_devtools_backend.js:4026 Warning: Encountered two children with the same key, `1754`. Keys should be unique so that components maintain their identity across updates. Non-unique keys may cause children to be duplicated and/or omitted — the behavior is unsupported and could change in a future version.
+    at div
+    at div
+    at div
+    at InfiniteScroll (http://localhost:3000/static/js/bundle.js:83036:24)
+    at div
+    at HomePage (http://localhost:3000/static/js/bundle.js:566:5)
+    at Routes (http://localhost:3000/static/js/bundle.js:85572:5)
+    at Router (http://localhost:3000/static/js/bundle.js:85505:15)
+    at BrowserRouter (http://localhost:3000/static/js/bundle.js:84314:5)
+    at div
+    at App (http://localhost:3000/static/js/bundle.js:47:88)
+overrideMethod @ react_devtools_backend.js:4026
+printWarning @ react-dom.development.js:86
+error @ react-dom.development.js:60
+warnOnInvalidKey @ react-dom.development.js:15293
+reconcileChildrenArray @ react-dom.development.js:15330
+reconcileChildFibers @ react-dom.development.js:15821
+reconcileChildren @ react-dom.development.js:19174
+updateHostComponent @ react-dom.development.js:19924
+beginWork @ react-dom.development.js:21618
+beginWork$1 @ react-dom.development.js:27426
+performUnitOfWork @ react-dom.development.js:26557
+workLoopSync @ react-dom.development.js:26466
+renderRootSync @ react-dom.development.js:26434
+performConcurrentWorkOnRoot @ react-dom.development.js:25738
+workLoop @ scheduler.development.js:266
+flushWork @ scheduler.development.js:239
+performWorkUntilDeadline @ scheduler.development.js:533
+HomePage.js:45 Data for tune #991 {format: 'json', id: 991, name: 'Lord Inchiquin', url: 'https://thesession.org/tunes/991', member: {…}, …}
+HomePage.js:45 Data for tune #590 {format: 'json', id: 590, name: 'Cherish The Ladies', url: 'https://thesession.org/tunes/590', member: {…}, …}
+HomePage.js:45 Data for tune #671 {format: 'json', id: 671, name: 'The Green Fields Of Glentown', url: 'https://thesession.org/tunes/671', member: {…}, …}
+HomePage.js:45 Data for tune #1637 {format: 'json', id: 1637, name: 'Molly Bán', url: 'https://thesession.org/tunes/1637', member: {…}, …}
+react_devtools_backend.js:4026 Warning: Encountered two children with the same key, `1754`. Keys should be unique so that components maintain their identity across updates. Non-unique keys may cause children to be duplicated and/or omitted — the behavior is unsupported and could change in a future version.
+    at div
+    at div
+    at div
+    at InfiniteScroll (http://localhost:3000/static/js/bundle.js:83036:24)
+    at div
+    at HomePage (http://localhost:3000/static/js/bundle.js:566:5)
+    at Routes (http://localhost:3000/static/js/bundle.js:85572:5)
+    at Router (http://localhost:3000/static/js/bundle.js:85505:15)
+    at BrowserRouter (http://localhost:3000/static/js/bundle.js:84314:5)
+    at div
+    at App (http://localhost:3000/static/js/bundle.js:47:88)
+overrideMethod @ react_devtools_backend.js:4026
+printWarning @ react-dom.development.js:86
+error @ react-dom.development.js:60
+warnOnInvalidKey @ react-dom.development.js:15293
+reconcileChildrenArray @ react-dom.development.js:15330
+reconcileChildFibers @ react-dom.development.js:15821
+reconcileChildren @ react-dom.development.js:19174
+updateHostComponent @ react-dom.development.js:19924
+beginWork @ react-dom.development.js:21618
+beginWork$1 @ react-dom.development.js:27426
+performUnitOfWork @ react-dom.development.js:26557
+workLoopSync @ react-dom.development.js:26466
+renderRootSync @ react-dom.development.js:26434
+performConcurrentWorkOnRoot @ react-dom.development.js:25738
+workLoop @ scheduler.development.js:266
+flushWork @ scheduler.development.js:239
+performWorkUntilDeadline @ scheduler.development.js:533
+HomePage.js:45 Data for tune #6 {format: 'json', id: 6, name: 'This Is My Love, Do You Like Her?', url: 'https://thesession.org/tunes/6', member: {…}, …}
+HomePage.js:45 Data for tune #1414 {format: 'json', id: 1414, name: 'The Brosna', url: 'https://thesession.org/tunes/1414', member: {…}, …}
+react_devtools_backend.js:4026 Warning: Encountered two children with the same key, `1754`. Keys should be unique so that components maintain their identity across updates. Non-unique keys may cause children to be duplicated and/or omitted — the behavior is unsupported and could change in a future version.
+    at div
+    at div
+    at div
+    at InfiniteScroll (http://localhost:3000/static/js/bundle.js:83036:24)
+    at div
+    at HomePage (http://localhost:3000/static/js/bundle.js:566:5)
+    at Routes (http://localhost:3000/static/js/bundle.js:85572:5)
+    at Router (http://localhost:3000/static/js/bundle.js:85505:15)
+    at BrowserRouter (http://localhost:3000/static/js/bundle.js:84314:5)
+    at div
+    at App (http://localhost:3000/static/js/bundle.js:47:88)
+overrideMethod @ react_devtools_backend.js:4026
+printWarning @ react-dom.development.js:86
+error @ react-dom.development.js:60
+warnOnInvalidKey @ react-dom.development.js:15293
+reconcileChildrenArray @ react-dom.development.js:15330
+reconcileChildFibers @ react-dom.development.js:15821
+reconcileChildren @ react-dom.development.js:19174
+updateHostComponent @ react-dom.development.js:19924
+beginWork @ react-dom.development.js:21618
+beginWork$1 @ react-dom.development.js:27426
+performUnitOfWork @ react-dom.development.js:26557
+workLoopSync @ react-dom.development.js:26466
+renderRootSync @ react-dom.development.js:26434
+performConcurrentWorkOnRoot @ react-dom.development.js:25738
+workLoop @ scheduler.development.js:266
+flushWork @ scheduler.development.js:239
+performWorkUntilDeadline @ scheduler.development.js:533
+HomePage.js:45 Data for tune #1142 {format: 'json', id: 1142, name: 'Trim The Velvet', url: 'https://thesession.org/tunes/1142', member: {…}, …}
+react_devtools_backend.js:4026 Warning: Encountered two children with the same key, `1754`. Keys should be unique so that components maintain their identity across updates. Non-unique keys may cause children to be duplicated and/or omitted — the behavior is unsupported and could change in a future version.
+    at div
+    at div
+    at div
+    at InfiniteScroll (http://localhost:3000/static/js/bundle.js:83036:24)
+    at div
+    at HomePage (http://localhost:3000/static/js/bundle.js:566:5)
+    at Routes (http://localhost:3000/static/js/bundle.js:85572:5)
+    at Router (http://localhost:3000/static/js/bundle.js:85505:15)
+    at BrowserRouter (http://localhost:3000/static/js/bundle.js:84314:5)
+    at div
+    at App (http://localhost:3000/static/js/bundle.js:47:88)
+overrideMethod @ react_devtools_backend.js:4026
+printWarning @ react-dom.development.js:86
+error @ react-dom.development.js:60
+warnOnInvalidKey @ react-dom.development.js:15293
+reconcileChildrenArray @ react-dom.development.js:15330
+reconcileChildFibers @ react-dom.development.js:15821
+reconcileChildren @ react-dom.development.js:19174
+updateHostComponent @ react-dom.development.js:19924
+beginWork @ react-dom.development.js:21618
+beginWork$1 @ react-dom.development.js:27426
+performUnitOfWork @ react-dom.development.js:26557
+workLoopSync @ react-dom.development.js:26466
+renderRootSync @ react-dom.development.js:26434
+performConcurrentWorkOnRoot @ react-dom.development.js:25738
+workLoop @ scheduler.development.js:266
+flushWork @ scheduler.development.js:239
+performWorkUntilDeadline @ scheduler.development.js:533
+HomePage.js:45 Data for tune #2067 {format: 'json', id: 2067, name: 'The Hut On Staffin Island', url: 'https://thesession.org/tunes/2067', member: {…}, …}
+HomePage.js:45 Data for tune #938 {format: 'json', id: 938, name: 'The Lady On The Island', url: 'https://thesession.org/tunes/938', member: {…}, …}
+HomePage.js:45 Data for tune #444 {format: 'json', id: 444, name: "Terry 'Cuz' Teehan's", url: 'https://thesession.org/tunes/444', member: {…}, …}
+react_devtools_backend.js:4026 Warning: Encountered two children with the same key, `1754`. Keys should be unique so that components maintain their identity across updates. Non-unique keys may cause children to be duplicated and/or omitted — the behavior is unsupported and could change in a future version.
+    at div
+    at div
+    at div
+    at InfiniteScroll (http://localhost:3000/static/js/bundle.js:83036:24)
+    at div
+    at HomePage (http://localhost:3000/static/js/bundle.js:566:5)
+    at Routes (http://localhost:3000/static/js/bundle.js:85572:5)
+    at Router (http://localhost:3000/static/js/bundle.js:85505:15)
+    at BrowserRouter (http://localhost:3000/static/js/bundle.js:84314:5)
+    at div
+    at App (http://localhost:3000/static/js/bundle.js:47:88)
+overrideMethod @ react_devtools_backend.js:4026
+printWarning @ react-dom.development.js:86
+error @ react-dom.development.js:60
+warnOnInvalidKey @ react-dom.development.js:15293
+reconcileChildrenArray @ react-dom.development.js:15330
+reconcileChildFibers @ react-dom.development.js:15821
+reconcileChildren @ react-dom.development.js:19174
+updateHostComponent @ react-dom.development.js:19924
+beginWork @ react-dom.development.js:21618
+beginWork$1 @ react-dom.development.js:27426
+performUnitOfWork @ react-dom.development.js:26557
+workLoopSync @ react-dom.development.js:26466
+renderRootSync @ react-dom.development.js:26434
+performConcurrentWorkOnRoot @ react-dom.development.js:25738
+workLoop @ scheduler.development.js:266
+flushWork @ scheduler.development.js:239
+performWorkUntilDeadline @ scheduler.development.js:533
+HomePage.js:45 Data for tune #2154 {format: 'json', id: 2154, name: "The Colliers'", url: 'https://thesession.org/tunes/2154', member: {…}, …}
+HomePage.js:45 Data for tune #2170 {format: 'json', id: 2170, name: 'Caisleán An Óir', url: 'https://thesession.org/tunes/2170', member: {…}, …}
+react_devtools_backend.js:4026 Warning: Encountered two children with the same key, `1754`. Keys should be unique so that components maintain their identity across updates. Non-unique keys may cause children to be duplicated and/or omitted — the behavior is unsupported and could change in a future version.
+    at div
+    at div
+    at div
+    at InfiniteScroll (http://localhost:3000/static/js/bundle.js:83036:24)
+    at div
+    at HomePage (http://localhost:3000/static/js/bundle.js:566:5)
+    at Routes (http://localhost:3000/static/js/bundle.js:85572:5)
+    at Router (http://localhost:3000/static/js/bundle.js:85505:15)
+    at BrowserRouter (http://localhost:3000/static/js/bundle.js:84314:5)
+    at div
+    at App (http://localhost:3000/static/js/bundle.js:47:88)
+overrideMethod @ react_devtools_backend.js:4026
+printWarning @ react-dom.development.js:86
+error @ react-dom.development.js:60
+warnOnInvalidKey @ react-dom.development.js:15293
+reconcileChildrenArray @ react-dom.development.js:15330
+reconcileChildFibers @ react-dom.development.js:15821
+reconcileChildren @ react-dom.development.js:19174
+updateHostComponent @ react-dom.development.js:19924
+beginWork @ react-dom.development.js:21618
+beginWork$1 @ react-dom.development.js:27426
+performUnitOfWork @ react-dom.development.js:26557
+workLoopSync @ react-dom.development.js:26466
+renderRootSync @ react-dom.development.js:26434
+performConcurrentWorkOnRoot @ react-dom.development.js:25738
+workLoop @ scheduler.development.js:266
+flushWork @ scheduler.development.js:239
+performWorkUntilDeadline @ scheduler.development.js:533
+HomePage.js:45 Data for tune #369 {format: 'json', id: 369, name: 'The Longford Tinker', url: 'https://thesession.org/tunes/369', member: {…}, …}
+react_devtools_backend.js:4026 Warning: Encountered two children with the same key, `1754`. Keys should be unique so that components maintain their identity across updates. Non-unique keys may cause children to be duplicated and/or omitted — the behavior is unsupported and could change in a future version.
+    at div
+    at div
+    at div
+    at InfiniteScroll (http://localhost:3000/static/js/bundle.js:83036:24)
+    at div
+    at HomePage (http://localhost:3000/static/js/bundle.js:566:5)
+    at Routes (http://localhost:3000/static/js/bundle.js:85572:5)
+    at Router (http://localhost:3000/static/js/bundle.js:85505:15)
+    at BrowserRouter (http://localhost:3000/static/js/bundle.js:84314:5)
+    at div
+    at App (http://localhost:3000/static/js/bundle.js:47:88)
+overrideMethod @ react_devtools_backend.js:4026
+printWarning @ react-dom.development.js:86
+error @ react-dom.development.js:60
+warnOnInvalidKey @ react-dom.development.js:15293
+reconcileChildrenArray @ react-dom.development.js:15330
+reconcileChildFibers @ react-dom.development.js:15821
+reconcileChildren @ react-dom.development.js:19174
+updateHostComponent @ react-dom.development.js:19924
+beginWork @ react-dom.development.js:21618
+beginWork$1 @ react-dom.development.js:27426
+performUnitOfWork @ react-dom.development.js:26557
+workLoopSync @ react-dom.development.js:26466
+renderRootSync @ react-dom.development.js:26434
+performConcurrentWorkOnRoot @ react-dom.development.js:25738
+workLoop @ scheduler.development.js:266
+flushWork @ scheduler.development.js:239
+performWorkUntilDeadline @ scheduler.development.js:533
+HomePage.js:45 Data for tune #866 {format: 'json', id: 866, name: 'The Ale Is Dear', url: 'https://thesession.org/tunes/866', member: {…}, …}
+HomePage.js:45 Data for tune #1314 {format: 'json', id: 1314, name: 'Down By The Sally Gardens', url: 'https://thesession.org/tunes/1314', member: {…}, …}
+HomePage.js:45 Data for tune #131 {format: 'json', id: 131, name: 'Young Tom Ennis', url: 'https://thesession.org/tunes/131', member: {…}, …}
+react_devtools_backend.js:4026 Warning: Encountered two children with the same key, `1754`. Keys should be unique so that components maintain their identity across updates. Non-unique keys may cause children to be duplicated and/or omitted — the behavior is unsupported and could change in a future version.
+    at div
+    at div
+    at div
+    at InfiniteScroll (http://localhost:3000/static/js/bundle.js:83036:24)
+    at div
+    at HomePage (http://localhost:3000/static/js/bundle.js:566:5)
+    at Routes (http://localhost:3000/static/js/bundle.js:85572:5)
+    at Router (http://localhost:3000/static/js/bundle.js:85505:15)
+    at BrowserRouter (http://localhost:3000/static/js/bundle.js:84314:5)
+    at div
+    at App (http://localhost:3000/static/js/bundle.js:47:88)
+overrideMethod @ react_devtools_backend.js:4026
+printWarning @ react-dom.development.js:86
+error @ react-dom.development.js:60
+warnOnInvalidKey @ react-dom.development.js:15293
+reconcileChildrenArray @ react-dom.development.js:15330
+reconcileChildFibers @ react-dom.development.js:15821
+reconcileChildren @ react-dom.development.js:19174
+updateHostComponent @ react-dom.development.js:19924
+beginWork @ react-dom.development.js:21618
+beginWork$1 @ react-dom.development.js:27426
+performUnitOfWork @ react-dom.development.js:26557
+workLoopSync @ react-dom.development.js:26466
+renderRootSync @ react-dom.development.js:26434
+performConcurrentWorkOnRoot @ react-dom.development.js:25738
+workLoop @ scheduler.development.js:266
+flushWork @ scheduler.development.js:239
+performWorkUntilDeadline @ scheduler.development.js:533
+HomePage.js:45 Data for tune #255 {format: 'json', id: 255, name: "Jean's", url: 'https://thesession.org/tunes/255', member: {…}, …}
+react_devtools_backend.js:4026 Warning: Encountered two children with the same key, `1754`. Keys should be unique so that components maintain their identity across updates. Non-unique keys may cause children to be duplicated and/or omitted — the behavior is unsupported and could change in a future version.
+    at div
+    at div
+    at div
+    at InfiniteScroll (http://localhost:3000/static/js/bundle.js:83036:24)
+    at div
+    at HomePage (http://localhost:3000/static/js/bundle.js:566:5)
+    at Routes (http://localhost:3000/static/js/bundle.js:85572:5)
+    at Router (http://localhost:3000/static/js/bundle.js:85505:15)
+    at BrowserRouter (http://localhost:3000/static/js/bundle.js:84314:5)
+    at div
+    at App (http://localhost:3000/static/js/bundle.js:47:88)
+overrideMethod @ react_devtools_backend.js:4026
+printWarning @ react-dom.development.js:86
+error @ react-dom.development.js:60
+warnOnInvalidKey @ react-dom.development.js:15293
+reconcileChildrenArray @ react-dom.development.js:15330
+reconcileChildFibers @ react-dom.development.js:15821
+reconcileChildren @ react-dom.development.js:19174
+updateHostComponent @ react-dom.development.js:19924
+beginWork @ react-dom.development.js:21618
+beginWork$1 @ react-dom.development.js:27426
+performUnitOfWork @ react-dom.development.js:26557
+workLoopSync @ react-dom.development.js:26466
+renderRootSync @ react-dom.development.js:26434
+performConcurrentWorkOnRoot @ react-dom.development.js:25738
+workLoop @ scheduler.development.js:266
+flushWork @ scheduler.development.js:239
+performWorkUntilDeadline @ scheduler.development.js:533

--- a/src/components/Navigation/Navigation.js
+++ b/src/components/Navigation/Navigation.js
@@ -16,7 +16,7 @@ export default function Navigation(props) {
       className="Navigation"
     >
       <Container>
-        <Navbar.Brand href="/">
+        <Navbar.Brand>
           <img
             alt="Violin"
             src="/violin.png"
@@ -24,7 +24,9 @@ export default function Navigation(props) {
             height="30"
             className="d-inline-block align-top"
           />
-          Tunes!
+          <NavLink to="/" className="nav-link d-inline-block">
+            Tunes!
+          </NavLink>
         </Navbar.Brand>
         <Navbar.Toggle aria-controls="basic-navbar-nav" />
         <Navbar.Collapse id="basic-navbar-nav">
@@ -40,9 +42,9 @@ export default function Navigation(props) {
                 ""
               )}
             </NavLink>
-            {/* <NavLink to="/practice" className="nav-link">
+            <NavLink to="/practice" className="nav-link">
               Practice
-            </NavLink> */}
+            </NavLink>
           </Nav>
         </Navbar.Collapse>
       </Container>

--- a/src/components/Practice/Practice.js
+++ b/src/components/Practice/Practice.js
@@ -1,8 +1,18 @@
-import React from 'react'
-import './Practice.css'
+import React from "react"
+import "./Practice.css"
 
-export default function Practice() {
+export default function Practice(
+  tuneBook,
+  toggleTuneBookEntry,
+  practiceDiary,
+  setPracticeDiary,
+  userPrefs,
+  setUserPrefs
+) {
   return (
-    <div>Shhh! Upcoming feature spoiler alert.<br></br>Nothing to see here.</div>
+    <div>
+      Shhh! Upcoming feature spoiler alert.<br></br>Nothing to see here.
+      {practiceDiary}
+    </div>
   )
 }

--- a/src/components/TuneBook/TuneBook.js
+++ b/src/components/TuneBook/TuneBook.js
@@ -1,4 +1,4 @@
-import { useState } from "react"
+import { useState, useEffect } from "react"
 import { NavLink } from "react-router-dom"
 import ChevronRightIcon from "@mui/icons-material/ChevronRight"
 import Button from "react-bootstrap/Button"
@@ -9,15 +9,40 @@ import "./TuneBook.css"
 
 export default function TuneBook(props) {
   const [show, setShow] = useState(false)
+  const [thesessionTunebook, setThesessionTunebook] = useState({})
 
   const handleClose = () => setShow(false)
   const handleShow = () => setShow(true)
 
-  const tuneSelection = () => {
+  const thesessionTuneSelection = () => {
+    return thesessionTunebook.tunes && thesessionTunebook.tunes.length > 0 ? (
+      <div className="tune-selection d-flex flex-column">
+        <div className="tune-selection-header">
+          <p>{thesessionTunebook.tunes.length} tunes in your thesession.org tunebook:</p>
+        </div>
+        {thesessionTunebook.tunes.map((entry) => (
+          <NavLink
+            className="tune-item"
+            tabIndex="0"
+            key={entry.url}
+            to={`./${entry.id}`}
+          >
+            <div className="tune-item-title">{entry.name}</div>
+          </NavLink>
+        ))}
+      </div>
+    ) : (
+      <div className="tune-selection tune-selection-empty">
+        <p>No tunes in your thesession.org tunebook</p>
+      </div>
+    )
+  }
+
+  const localTuneSelection = () => {
     return props.tuneBook.length > 0 ? (
       <div className="tune-selection d-flex flex-column">
         <div className="tune-selection-header">
-          <h3>Select a tune:</h3>
+          <p>{props.tuneBook.length} tunes in your local tunebook:</p>
         </div>
         {props.tuneBook.map((entry) => (
           <NavLink
@@ -32,26 +57,60 @@ export default function TuneBook(props) {
       </div>
     ) : (
       <div className="tune-selection tune-selection-empty">
-        <p>No tunes in tunebook</p>
+        <p>No tunes in your local tunebook</p>
       </div>
     )
   }
 
+  useEffect(() => {
+    const thesessionTunebookUrl = `https://thesession.org/members/${props.userPrefs.thesessionMemberId}/tunebook?format=json`
+    console.log(
+      `Looking up thesession.org tunebook for member ${props.userPrefs.thesessionMemberId}`
+    )
+    fetch(thesessionTunebookUrl)
+      .then((response) => response.json())
+      .then((data) => {
+        console.log(
+          `--> Found ${data.total} tunes in thesession.org tunebook for member ${props.userPrefs.thesessionMemberId}`
+        )
+        setThesessionTunebook(data)
+      })
+      .catch((error) => {
+        console.log("error fething thesession.org tunebook:", error)
+      })
+  }, [props.userPrefs.thesessionMemberId])
+
   return (
     <div className="TuneBook">
       <div className="offcanvas-button d-lg-none col-1">
-        <Button variant="primary" className="open-tunebook d-lg-none" onClick={handleShow}>
-          <ChevronRightIcon />open tunebook
+        <Button
+          variant="primary"
+          className="open-tunebook d-lg-none"
+          onClick={handleShow}
+        >
+          <ChevronRightIcon />
+          open tunebook
         </Button>
       </div>
 
       <div className="score-area d-flex">
         <div className="tune-selection-large d-none d-lg-block">
-          {tuneSelection()}
+          {thesessionTuneSelection()}
+          {localTuneSelection()}
         </div>
         <TuneNotation
           tuneBook={props.tuneBook}
           toggleTuneBookEntry={props.toggleTuneBookEntry}
+          resultsList={props.resultsList}
+          setResultsList={props.setResultsList}
+          filters={props.filters}
+          setFilters={props.setFilters}
+          userPrefs={props.userPrefs}
+          setUserPrefs={props.setUserPrefs}
+          practiceDiary={props.practiceDiary}
+          setPracticeDiary={props.setPracticeDiary}
+          preferredSettings={props.preferredSettings}
+          managePreferredSettings={props.managePreferredSettings}
         />
       </div>
 
@@ -60,7 +119,8 @@ export default function TuneBook(props) {
           <Offcanvas.Title>My tunebook</Offcanvas.Title>
         </Offcanvas.Header>
         <Offcanvas.Body>
-          <div>{tuneSelection()}</div>
+          <div>{thesessionTuneSelection()}</div>
+          <div>{localTuneSelection()}</div>
         </Offcanvas.Body>
       </Offcanvas>
     </div>

--- a/src/components/TuneResult/TuneResult.css
+++ b/src/components/TuneResult/TuneResult.css
@@ -39,8 +39,13 @@
   flex-shrink: 0;
 }
 
-.TuneResult .tune-filters .tune-in {
+.TuneResult .tune-filters .tune-in .tune-id {
   padding: 0 3px;
+}
+
+.TuneResult .tune-id {
+  color: var(--text-muted);
+  font-size: smaller;
 }
 
 .TuneResult .tune-filters button {

--- a/src/index.css
+++ b/src/index.css
@@ -7,6 +7,7 @@
   --bg-mode: rgb(96, 136, 83);
   --addbutton-muted: rgb(194, 97, 97);
   --addbutton: rgb(230, 50, 50);
+  --text-muted: rgb(177, 177, 177);
 }
 
 body {

--- a/src/parseABC.js
+++ b/src/parseABC.js
@@ -1,0 +1,6 @@
+export default function parseABC(abc) {
+  abc = abc.replace(/\|!/g, "|") // remove thesession.org's custom pagination (exclamation marks)
+  abc = abc.replace(/:\| \|:/g, ":||:") // remove double barline spaces
+  abc = abc.replace(/(K:[a-zA-Z\s]*)!/g, "[$1]") // deal with inline key signature changes
+  return abc
+}


### PR DESCRIPTION
User preferences object added to App state. User can now elect to only show search results in which the FIRST (primary) setting of a tune matches the search filters.

Added 'preferred settings' feature - user's preferred tune settings are stored in localStorage for now.

Removed problematic InfiniteScroll element (problems may be caused by excessive API calling, perhaps as a result of unexpected re-rendering of Homepage component). 